### PR TITLE
Fix: We should add an option under pluginMenu that allows for manual toggle o

### DIFF
--- a/json/labels.json
+++ b/json/labels.json
@@ -470,6 +470,9 @@
     },
     "encounterPhase": {
       "English": "Encounter Phase"
+    },
+    "toggleEncounterDeck2": {
+      "English": "Toggle Second Encounter Deck"
     }
   }
 }

--- a/json/pluginMenu.json
+++ b/json/pluginMenu.json
@@ -1,6 +1,7 @@
 {
   "pluginMenu": {
     "options": [
+      {"label": "id:toggleEncounterDeck2", "actionList": ["TOGGLE_ENCOUNTER_2_DECK", ["NOT", "$GAME.layoutregions.sharedEncounter2Deck.visible"]]}
     ]
   }
 }


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413108723396618/1502814196436570322

**Description:**
> We should add an option under pluginMenu that allows for manual toggle on/off of the second encounter deck rather than relying on the automation from decks that have cards in their second encounter deck
