### PR TITLE
Fix: Ok, let's add 2 player properties heroHandSizeModifier and alterEgoHandS

### DIFF
--- a/json/automation.json
+++ b/json/automation.json
@@ -284,14 +284,89 @@
     ],
     "gameRules": {
       "handSize": {
-        "_comment": "When a card enters play or flips, if it has a hand size, set the player's hand size to that value.",
+        "_comment": "When a card enters play or flips, if it has a hand size, set the player's hand size to that value plus the applicable modifier.",
         "type": "trigger",
         "listenTo": ["/cardById/*/inPlay", "/cardById/*/currentSide"],
         "condition": ["AND", "$TARGET.inPlay", ["NOT_EQUAL", "$TARGET.currentFace.handSize", null]],
         "then": [
           ["VAR", "$CONTROLLER", "$TARGET.controller"],
-          ["SET", "/playerData/$CONTROLLER/handSize", "$TARGET.currentFace.handSize"],
-          ["LOG", "$ALIAS_N", " set their hand size to ", "$TARGET.currentFace.handSize", "."]
+          ["VAR", "$MODIFIER", 0],
+          ["COND",
+            ["EQUAL", "$TARGET.currentFace.type", "Hero"],
+            ["UPDATE_VAR", "$MODIFIER", "$GAME.playerData.$CONTROLLER.heroHandSizeModifier"],
+            ["EQUAL", "$TARGET.currentFace.type", "Alter-Ego"],
+            ["UPDATE_VAR", "$MODIFIER", "$GAME.playerData.$CONTROLLER.alterEgoHandSizeModifier"]
+          ],
+          ["SET", "/playerData/$CONTROLLER/handSize", ["ADD", "$TARGET.currentFace.handSize", "$MODIFIER"]],
+          ["LOG", "$ALIAS_N", " set their hand size to ", ["ADD", "$TARGET.currentFace.handSize", "$MODIFIER"], "."]
+        ]
+      },
+      "heroHandSizeModifierChanged": {
+        "_comment": "When heroHandSizeModifier changes, recalculate hand size if the hero side is currently up.",
+        "type": "trigger",
+        "listenTo": ["/playerData/*/heroHandSizeModifier"],
+        "condition": ["GREATER_THAN",
+          ["LENGTH",
+            ["FILTER_CARDS", "$IDENTITY_CARD",
+              ["AND",
+                "$IDENTITY_CARD.inPlay",
+                ["EQUAL", "$IDENTITY_CARD.controller", "$TARGET_ID"],
+                ["NOT_EQUAL", "$IDENTITY_CARD.currentFace.handSize", null],
+                ["EQUAL", "$IDENTITY_CARD.currentFace.type", "Hero"]
+              ]
+            ]
+          ],
+          0
+        ],
+        "then": [
+          ["FOR_EACH_KEY_VAL", "$CARD_ID", "$CARD", "$GAME.cardById",
+            ["COND",
+              ["AND",
+                "$CARD.inPlay",
+                ["EQUAL", "$CARD.controller", "$TARGET_ID"],
+                ["NOT_EQUAL", "$CARD.currentFace.handSize", null],
+                ["EQUAL", "$CARD.currentFace.type", "Hero"]
+              ],
+              [
+                ["SET", "/playerData/$TARGET_ID/handSize", ["ADD", "$CARD.currentFace.handSize", "$TARGET.heroHandSizeModifier"]],
+                ["LOG", "$ALIAS_N", " updated their hand size to ", ["ADD", "$CARD.currentFace.handSize", "$TARGET.heroHandSizeModifier"], "."]
+              ]
+            ]
+          ]
+        ]
+      },
+      "alterEgoHandSizeModifierChanged": {
+        "_comment": "When alterEgoHandSizeModifier changes, recalculate hand size if the alter ego side is currently up.",
+        "type": "trigger",
+        "listenTo": ["/playerData/*/alterEgoHandSizeModifier"],
+        "condition": ["GREATER_THAN",
+          ["LENGTH",
+            ["FILTER_CARDS", "$IDENTITY_CARD",
+              ["AND",
+                "$IDENTITY_CARD.inPlay",
+                ["EQUAL", "$IDENTITY_CARD.controller", "$TARGET_ID"],
+                ["NOT_EQUAL", "$IDENTITY_CARD.currentFace.handSize", null],
+                ["EQUAL", "$IDENTITY_CARD.currentFace.type", "Alter-Ego"]
+              ]
+            ]
+          ],
+          0
+        ],
+        "then": [
+          ["FOR_EACH_KEY_VAL", "$CARD_ID", "$CARD", "$GAME.cardById",
+            ["COND",
+              ["AND",
+                "$CARD.inPlay",
+                ["EQUAL", "$CARD.controller", "$TARGET_ID"],
+                ["NOT_EQUAL", "$CARD.currentFace.handSize", null],
+                ["EQUAL", "$CARD.currentFace.type", "Alter-Ego"]
+              ],
+              [
+                ["SET", "/playerData/$TARGET_ID/handSize", ["ADD", "$CARD.currentFace.handSize", "$TARGET.alterEgoHandSizeModifier"]],
+                ["LOG", "$ALIAS_N", " updated their hand size to ", ["ADD", "$CARD.currentFace.handSize", "$TARGET.alterEgoHandSizeModifier"], "."]
+              ]
+            ]
+          ]
         ]
       },
       "setSideSchemeStartingThreat": {

--- a/json/labels.json
+++ b/json/labels.json
@@ -300,6 +300,12 @@
     "handSize": {
       "English": "Hand Size"
     },
+    "heroHandSizeModifier": {
+      "English": "Hero Hand Size Modifier"
+    },
+    "alterEgoHandSizeModifier": {
+      "English": "Alter-Ego Hand Size Modifier"
+    },
     "zeroTokens": {
       "English": "Remove All Tokens"
     },

--- a/json/playerProperties.json
+++ b/json/playerProperties.json
@@ -1,6 +1,8 @@
 {
   "playerProperties": {
     "hitPoints":  {"type": "integer", "default": 0, "min": 0, "label": "id:hitPoints"},
-    "handSize": {"type": "integer", "default": 0, "min": 0, "label": "id:handSize"}
+    "handSize": {"type": "integer", "default": 0, "min": 0, "label": "id:handSize"},
+    "heroHandSizeModifier": {"type": "integer", "default": 0, "label": "id:heroHandSizeModifier"},
+    "alterEgoHandSizeModifier": {"type": "integer", "default": 0, "label": "id:alterEgoHandSizeModifier"}
   }
 }

--- a/json/preferences.json
+++ b/json/preferences.json
@@ -1,6 +1,6 @@
 {
     "preferences": {
         "game": ["loadMode", "loadRequired", "loadRecommends", "mode", "standardSet", "expertSet"],
-        "player": []
+        "player": ["heroHandSizeModifier", "alterEgoHandSizeModifier"]
     }
 }


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413039068598353/1511482942889791539

**Description:**
> Ok, let's add 2 player properties heroHandSizeModifier and alterEgoHandSizeModifier and add them to preferences. The we'll update the automation when a card with handSize enters play to also add the modifier based on whether the card is hero side up or alter ego side up. Let's also add automation so that when one of the modifiers is changed, it checks if hero side is up or alter ego side is up, and if the corresponding modifier was changed, the hand size is recalculated.
