### PR TITLE
Import custom deck

### DIFF
--- a/json/actionLists.json
+++ b/json/actionLists.json
@@ -181,6 +181,69 @@
       ["POINTER",
         ["EQUAL", "$CARD.sides.A.type", "Side Scheme"]
       ]
+    ],
+    "importMc4dbDeck": [
+      ["VAR", "$URL", "$PROMPT_INPUT"],
+      ["COND",
+        ["EQUAL", "$URL", null],
+        ["ABORT", "No URL provided."]
+      ],
+
+      ["VAR", "$DECK_TYPE", "decklist"],
+      ["COND",
+        ["NOT", ["IN_STRING", "$URL", "decklist"]],
+        ["UPDATE_VAR", "$DECK_TYPE", "deck"]
+      ],
+
+      ["VAR", "$TYPE_INDEX", ["INDEX_OF", "$URL", "$DECK_TYPE"]],
+      ["VAR", "$BASE_URL", ["SUBSTRING", "$URL", 0, ["SUBTRACT", "$TYPE_INDEX", 1]]],
+
+      ["VAR", "$VIEW_INDEX", ["INDEX_OF", "$URL", "view"]],
+      ["VAR", "$ID_START", ["ADD", "$VIEW_INDEX", 5]],
+      ["VAR", "$DECK_ID", ["SUBSTRING", "$URL", "$ID_START", ["SUBTRACT", ["LENGTH", "$URL"], "$ID_START"]]],
+
+      ["VAR", "$API_URL", "{{$BASE_URL}}/api/public/{{$DECK_TYPE}}/{{$DECK_ID}}.json"],
+      ["LOG", "{{$ALIAS_N}} is importing a deck from {{$BASE_URL}}..."],
+
+      ["VAR", "$DECKLIST", ["REQUEST_JSON", "$API_URL"]],
+      ["COND",
+        ["EQUAL", "$DECKLIST", null],
+        ["ABORT", "Failed to fetch decklist from URL."]
+      ],
+
+      ["VAR", "$HERO_CODE", "$DECKLIST.hero_code"],
+      ["VAR", "$HERO_A_JSON", ["REQUEST_JSON", "{{$BASE_URL}}/api/public/card/{{$HERO_CODE}}.json"]],
+
+      ["VAR", "$HERO_B_CODE", ["REGEX_REPLACE", "$HERO_CODE", "a$", "b"]],
+      ["VAR", "$HERO_B_JSON", ["REQUEST_JSON", "{{$BASE_URL}}/api/public/card/{{$HERO_B_CODE}}.json"]],
+
+      ["VAR", "$FACE_A", ["BUILD_MC4DB_FACE", "$HERO_A_JSON", "$BASE_URL"]],
+      ["VAR", "$FACE_B", ["BUILD_MC4DB_FACE", "$HERO_B_JSON", "$BASE_URL"]],
+      ["VAR", "$HERO_DETAILS", ["MAP_PUT", ["MAP_PUT", {}, "A", "$FACE_A"], "B", "$FACE_B"]],
+      ["VAR", "$HERO_ITEM", ["PROCESS_MAP", {
+        "databaseId": null,
+        "quantity": 1,
+        "loadGroupId": "playerNPlay1",
+        "cardDetails": "$HERO_DETAILS"
+      }]],
+
+      ["VAR", "$LOAD_LIST", ["LIST", "$HERO_ITEM"]],
+
+      ["FOR_EACH_KEY_VAL", "$SLOT_CODE", "$SLOT_QTY", "$DECKLIST.slots", [
+        ["VAR", "$SLOT_JSON", ["REQUEST_JSON", "{{$BASE_URL}}/api/public/card/{{$SLOT_CODE}}.json"]],
+        ["VAR", "$SLOT_FACE", ["BUILD_MC4DB_FACE", "$SLOT_JSON", "$BASE_URL"]],
+        ["VAR", "$SLOT_DETAILS", ["MAP_PUT", ["MAP_PUT", {}, "A", "$SLOT_FACE"], "B", {"name": "player"}]],
+        ["VAR", "$SLOT_ITEM", ["PROCESS_MAP", {
+          "databaseId": null,
+          "quantity": "$SLOT_QTY",
+          "loadGroupId": "playerNDeck",
+          "cardDetails": "$SLOT_DETAILS"
+        }]],
+        ["UPDATE_VAR", "$LOAD_LIST", ["APPEND", "$LOAD_LIST", "$SLOT_ITEM"]]
+      ]],
+
+      ["LOAD_CARDS", "$LOAD_LIST"],
+      ["LOG", "{{$ALIAS_N}} finished importing deck from mc4db."]
     ]
   }
 }

--- a/json/announcements.json
+++ b/json/announcements.json
@@ -1,5 +1,6 @@
 {
   "announcements": [
+    "2026-06-03: Feat: Import custom deck via Ctrl+K (paste mc4db URL).",
     "2025-11-03: Feat: Add Civil War Encounter Cards.",
     "2025-10-25: Feat: Add Civil War Player Cards.",
     "2025-10-05: Feat: Add Standard/Expert Set info to save game metadata",
@@ -18,7 +19,7 @@
     "2025-04-04: Feat: Add Agents of S.H.I.E.L.D. Enounter Cards.",
     "2025-03-26: Feat: Add Agents of S.H.I.E.L.D. Player Cards.",
     "2024-12-23: Feat: Add Portugese language support.",
-    "2024-12-19: Fix: SP//dr nemesis set includes all copies of Energy Drain.",
+    "2024-12-19: Fix: Spider-Man + Doctor Strange nemesis set includes all copies of Energy Drain.",
     "2024-11-28: Fix: Loading Magneto Scenario.",
     "2024-11-27: Feat: Add Magneto Hero Pack.",
     "2024-10-02: Feat: Add Nightcrawler Hero Pack.",

--- a/json/automation.json
+++ b/json/automation.json
@@ -181,7 +181,7 @@
         ],
         [
           ["LOG", "LOADING Peni Parker"],
-          ["LOAD_CARDS", "SP//dr (Peni Parker)"]
+          ["LOAD_CARDS", "SP\/\/dr (Peni Parker)"]
         ]
       ],
       ["COND", ["AND", "$LOADED_PLAYER_DECK", ["EQUAL", "$GAME.roundNumber", 0]],
@@ -201,7 +201,10 @@
                 ["NOT", ["DEFINED", "$BUNDLE"]],
                 ["DEFINE", "$BUNDLE", "{{$IDENTITY_CARD.sides.$HERO_SIDE.name}} (Hero) [marvelcdb bundle]"]
               ],
-              ["LOAD_CARDS", "$BUNDLE"]
+              ["COND",
+                ["NOT_EQUAL", "$GAME_DEF.preBuiltDecks.$BUNDLE", null],
+                ["LOAD_CARDS", "$BUNDLE"]
+              ]
             ]
           ],
           ["COND",

--- a/json/deckMenu(3).json
+++ b/json/deckMenu(3).json
@@ -1,0 +1,1326 @@
+{
+  "deckMenu": {
+    "subMenus": [
+      {
+        "label": "Modular Sets",
+        "subMenus": [
+          {
+            "label": "Kree Fanatic",
+            "deckLists": [
+              {
+                "label": "Kree Fanatic",
+                "deckListId": "Kree Fanatic"
+              }
+            ]
+          },
+          {
+            "label": "Core Set",
+            "deckLists": [
+              {
+                "label": "Bomb Scare",
+                "deckListId": "Bomb Scare"
+              },
+              {
+                "label": "Masters of Evil",
+                "deckListId": "Masters of Evil"
+              },
+              {
+                "label": "Under Attack",
+                "deckListId": "Under Attack"
+              },
+              {
+                "label": "Legions of Hydra",
+                "deckListId": "Legions of Hydra"
+              },
+              {
+                "label": "The Doomsday Chair",
+                "deckListId": "The Doomsday Chair"
+              },
+              {
+                "label": "Standard",
+                "deckListId": "Standard"
+              },
+              {
+                "label": "Expert",
+                "deckListId": "Expert"
+              }
+            ]
+          },
+          {
+            "label": "The Green Goblin",
+            "deckLists": [
+              {
+                "label": "Goblin Gimmicks",
+                "deckListId": "Goblin Gimmicks"
+              },
+              {
+                "label": "A Mess of Things",
+                "deckListId": "A Mess of Things"
+              },
+              {
+                "label": "Power Drain",
+                "deckListId": "Power Drain"
+              },
+              {
+                "label": "Running Interference",
+                "deckListId": "Running Interference"
+              }
+            ]
+          },
+          {
+            "label": "The Rise of Red Skull",
+            "deckLists": [
+              {
+                "label": "Experimental Weapons",
+                "deckListId": "Experimental Weapons"
+              },
+              {
+                "label": "Hydra Assault",
+                "deckListId": "Hydra Assault"
+              },
+              {
+                "label": "Weapon Master",
+                "deckListId": "Weapon Master"
+              },
+              {
+                "label": "Hydra Patrol",
+                "deckListId": "Hydra Patrol"
+              }
+            ]
+          },
+          {
+            "label": "The Once and Future Kang",
+            "deckLists": [
+              {
+                "label": "Temporal",
+                "deckListId": "Temporal"
+              },
+              {
+                "label": "Anachronauts",
+                "deckListId": "Anachronauts"
+              },
+              {
+                "label": "Master of Time",
+                "deckListId": "Master of Time"
+              }
+            ]
+          },
+          {
+            "label": "Galaxy's Most Wanted",
+            "deckLists": [
+              {
+                "label": "Band of Badoon",
+                "deckListId": "Band of Badoon"
+              },
+              {
+                "label": "Galactic Artifacts",
+                "deckListId": "Galactic Artifacts"
+              },
+              {
+                "label": "Kree Militants",
+                "deckListId": "Kree Militants"
+              },
+              {
+                "label": "Menagerie Medley",
+                "deckListId": "Menagerie Medley"
+              },
+              {
+                "label": "Space Pirates",
+                "deckListId": "Space Pirates"
+              },
+              {
+                "label": "Ship Command",
+                "deckListId": "Ship Command"
+              },
+              {
+                "label": "Power Stone",
+                "deckListId": "Power Stone"
+              },
+              {
+                "label": "Badoon Headhunter",
+                "deckListId": "Badoon Headhunter"
+              }
+            ]
+          },
+          {
+            "label": "The Mad Titan's Shadow",
+            "deckLists": [
+              {
+                "label": "Black Order",
+                "deckListId": "Black Order"
+              },
+              {
+                "label": "Armies of Titan",
+                "deckListId": "Armies of Titan"
+              },
+              {
+                "label": "Children of Thanos",
+                "deckListId": "Children of Thanos"
+              },
+              {
+                "label": "Infinity Gauntlet",
+                "deckListId": "Infinity Gauntlet"
+              },
+              {
+                "label": "Legions of Hel",
+                "deckListId": "Legions of Hel"
+              },
+              {
+                "label": "Frost Giants",
+                "deckListId": "Frost Giants"
+              },
+              {
+                "label": "Enchantress",
+                "deckListId": "Enchantress"
+              }
+            ]
+          },
+          {
+            "label": "The Hood",
+            "deckLists": [
+              {
+                "label": "Beasty Boys",
+                "deckListId": "Beasty Boys"
+              },
+              {
+                "label": "Brothers Grimm",
+                "deckListId": "Brothers Grimm"
+              },
+              {
+                "label": "Crossfire's Crew",
+                "deckListId": "Crossfire's Crew"
+              },
+              {
+                "label": "Expert II",
+                "deckListId": "Expert II"
+              },
+              {
+                "label": "Mister Hyde",
+                "deckListId": "Mister Hyde"
+              },
+              {
+                "label": "Ransacked Armory",
+                "deckListId": "Ransacked Armory"
+              },
+              {
+                "label": "Sinister Syndicate",
+                "deckListId": "Sinister Syndicate"
+              },
+              {
+                "label": "Standard II",
+                "deckListId": "Standard II"
+              },
+              {
+                "label": "State of Emergency",
+                "deckListId": "State of Emergency"
+              },
+              {
+                "label": "Streets of Mayhem",
+                "deckListId": "Streets of Mayhem"
+              },
+              {
+                "label": "Wrecking Crew",
+                "deckListId": "Wrecking Crew"
+              }
+            ]
+          },
+          {
+            "label": "Sinister Motives",
+            "deckLists": [
+              {
+                "label": "City in Chaos",
+                "deckListId": "City in Chaos"
+              },
+              {
+                "label": "Down to Earth",
+                "deckListId": "Down to Earth"
+              },
+              {
+                "label": "Goblin Gear",
+                "deckListId": "Goblin Gear"
+              },
+              {
+                "label": "Guerrilla Tactics",
+                "deckListId": "Guerrilla Tactics"
+              },
+              {
+                "label": "Osborn Tech",
+                "deckListId": "Osborn Tech"
+              },
+              {
+                "label": "Personal Nightmare",
+                "deckListId": "Personal Nightmare"
+              },
+              {
+                "label": "Sinister Assault",
+                "deckListId": "Sinister Assault"
+              },
+              {
+                "label": "Symbiotic Strength",
+                "deckListId": "Symbiotic Strength"
+              },
+              {
+                "label": "Whispers of Paranoia",
+                "deckListId": "Whispers of Paranoia"
+              }
+            ]
+          },
+          {
+            "label": "Nova",
+            "deckLists": [
+              {
+                "label": "Armadillo",
+                "deckListId": "Armadillo"
+              }
+            ]
+          },
+          {
+            "label": "Ironheart",
+            "deckLists": [
+              {
+                "label": "Zzzax",
+                "deckListId": "Zzzax"
+              }
+            ]
+          },
+          {
+            "label": "Spider-Ham",
+            "deckLists": [
+              {
+                "label": "The Inheritors",
+                "deckListId": "The Inheritors"
+              }
+            ]
+          },
+          {
+            "label": "SP\/\/dr",
+            "deckLists": [
+              {
+                "label": "Iron Spider's Sinister Six",
+                "deckListId": "Iron Spider's Sinister Six"
+              }
+            ]
+          },
+          {
+            "label": "Mutant Genesis",
+            "deckLists": [
+              {
+                "label": "Brotherhood",
+                "deckListId": "Brotherhood"
+              },
+              {
+                "label": "Mystique",
+                "deckListId": "Mystique"
+              },
+              {
+                "label": "Zero Tolerance",
+                "deckListId": "Zero Tolerance"
+              },
+              {
+                "label": "Sentinels",
+                "deckListId": "Sentinels"
+              },
+              {
+                "label": "Acolytes",
+                "deckListId": "Acolytes"
+              },
+              {
+                "label": "Future Past",
+                "deckListId": "Future Past"
+              }
+            ]
+          },
+          {
+            "label": "Wolverine",
+            "deckLists": [
+              {
+                "label": "Deathstrike",
+                "deckListId": "Deathstrike"
+              }
+            ]
+          },
+          {
+            "label": "Storm",
+            "deckLists": [
+              {
+                "label": "Shadow King",
+                "deckListId": "Shadow King"
+              }
+            ]
+          },
+          {
+            "label": "Gambit",
+            "deckLists": [
+              {
+                "label": "Exodus",
+                "deckListId": "Exodus"
+              }
+            ]
+          },
+          {
+            "label": "Rogue",
+            "deckLists": [
+              {
+                "label": "Reavers",
+                "deckListId": "Reavers"
+              }
+            ]
+          },
+          {
+            "label": "MojoMania",
+            "deckLists": [
+              {
+                "label": "Crime",
+                "deckListId": "Crime"
+              },
+              {
+                "label": "Fantasy",
+                "deckListId": "Fantasy"
+              },
+              {
+                "label": "Horror",
+                "deckListId": "Horror"
+              },
+              {
+                "label": "Sci-Fi",
+                "deckListId": "Sci-Fi"
+              },
+              {
+                "label": "Sitcom",
+                "deckListId": "Sitcom"
+              },
+              {
+                "label": "Western",
+                "deckListId": "Western"
+              }
+            ]
+          },
+          {
+            "label": "NeXt Evolution",
+            "deckLists": [
+              {
+                "label": "Military Grade",
+                "deckListId": "Military Grade"
+              },
+              {
+                "label": "Mutant Slayers",
+                "deckListId": "Mutant Slayers"
+              },
+              {
+                "label": "Nasty Boys",
+                "deckListId": "Nasty Boys"
+              },
+              {
+                "label": "Hope Summers",
+                "deckListId": "Hope Summers"
+              },
+              {
+                "label": "Black Tom Cassidy",
+                "deckListId": "Black Tom Cassidy"
+              },
+              {
+                "label": "Flight",
+                "deckListId": "Flight"
+              },
+              {
+                "label": "Super Strength",
+                "deckListId": "Super Strength"
+              },
+              {
+                "label": "Telepathy",
+                "deckListId": "Telepathy"
+              },
+              {
+                "label": "Extreme Measures",
+                "deckListId": "Extreme Measures"
+              },
+              {
+                "label": "Mutant Insurrection",
+                "deckListId": "Mutant Insurrection"
+              }
+            ]
+          },
+          {
+            "label": "Deadpool",
+            "deckLists": [
+              {
+                "label": "Dreadpool",
+                "deckListId": "Dreadpool"
+              }
+            ]
+          },
+          {
+            "label": "Age of Apocalypse",
+            "deckLists": [
+              {
+                "label": "Infinites",
+                "deckListId": "Infinites"
+              },
+              {
+                "label": "Dystopian Nightmare",
+                "deckListId": "Dystopian Nightmare"
+              },
+              {
+                "label": "Standard III",
+                "deckListId": "Standard III"
+              },
+              {
+                "label": "Hounds",
+                "deckListId": "Hounds"
+              },
+              {
+                "label": "Dark Riders",
+                "deckListId": "Dark Riders"
+              },
+              {
+                "label": "Savage Land",
+                "deckListId": "Savage Land"
+              },
+              {
+                "label": "Genosha",
+                "deckListId": "Genosha"
+              },
+              {
+                "label": "Blue Moon",
+                "deckListId": "Blue Moon"
+              },
+              {
+                "label": "Celestial Tech",
+                "deckListId": "Celestial Tech"
+              },
+              {
+                "label": "Clan Akkaba",
+                "deckListId": "Clan Akkaba"
+              },
+              {
+                "label": "Prelates",
+                "deckListId": "Prelates"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Campaign",
+        "subMenus": [
+          {
+            "label": "The Rise of Red Skull",
+            "deckLists": [
+              {
+                "label": "Hydra Campaign",
+                "deckListId": "Hydra Campaign"
+              },
+              {
+                "label": "Expert Campaign",
+                "deckListId": "Expert Campaign"
+              }
+            ]
+          },
+          {
+            "label": "Galaxy's Most Wanted",
+            "deckLists": [
+              {
+                "label": "Campaign - The Market",
+                "deckListId": "Campaign - The Market"
+              },
+              {
+                "label": "Campaign - Expert Challenge",
+                "deckListId": "Campaign - Expert Challenge"
+              },
+              {
+                "label": "Campaign - Standard Challenge",
+                "deckListId": "Campaign - Standard Challenge"
+              }
+            ]
+          },
+          {
+            "label": "The Mad Titan's Shadow",
+            "deckLists": [
+              {
+                "label": "Campaign (The Mad Titan's Shadow)",
+                "deckListId": "Campaign (The Mad Titan's Shadow)"
+              }
+            ]
+          },
+          {
+            "label": "Sinister Motives",
+            "deckLists": [
+              {
+                "label": "Campaign - Bad Publicity",
+                "deckListId": "Campaign - Bad Publicity"
+              },
+              {
+                "label": "Campaign - Community Service",
+                "deckListId": "Campaign - Community Service"
+              },
+              {
+                "label": "Campaign - Snitches Get Stitches",
+                "deckListId": "Campaign - Snitches Get Stitches"
+              },
+              {
+                "label": "Campaign - S.H.I.E.L.D. Tech",
+                "deckListId": "Campaign - S.H.I.E.L.D. Tech"
+              }
+            ]
+          },
+          {
+            "label": "Mutant Genesis",
+            "deckLists": [
+              {
+                "label": "Campaign (Mutant Genesis)",
+                "deckListId": "Campaign (Mutant Genesis)"
+              },
+              {
+                "label": "Brawler",
+                "deckListId": "Brawler"
+              },
+              {
+                "label": "Commander",
+                "deckListId": "Commander"
+              },
+              {
+                "label": "Defender",
+                "deckListId": "Defender"
+              },
+              {
+                "label": "Peacekeeper",
+                "deckListId": "Peacekeeper"
+              }
+            ]
+          },
+          {
+            "label": "MojoMania",
+            "deckLists": [
+              {
+                "label": "Longshot",
+                "deckListId": "Longshot"
+              }
+            ]
+          },
+          {
+            "label": "NeXt Evolution",
+            "deckLists": [
+              {
+                "label": "Campaign (NeXt Evolution)",
+                "deckListId": "Campaign (NeXt Evolution)"
+              }
+            ]
+          },
+          {
+            "label": "Age of Apocalypse",
+            "deckLists": [
+              {
+                "label": "Age of Apocalypse",
+                "deckListId": "Age of Apocalypse"
+              },
+              {
+                "label": "Mission",
+                "deckListId": "Mission"
+              },
+              {
+                "label": "Campaign (Age of Apocalypse)",
+                "deckListId": "Campaign (Age of Apocalypse)"
+              },
+              {
+                "label": "Overseer",
+                "deckListId": "Overseer"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Scenarios",
+        "subMenus": [
+          {
+            "label": "Core Set",
+            "deckLists": [
+              {
+                "label": "Rhino",
+                "deckListId": "Rhino"
+              },
+              {
+                "label": "Klaw",
+                "deckListId": "Klaw"
+              },
+              {
+                "label": "Ultron",
+                "deckListId": "Ultron"
+              }
+            ]
+          },
+          {
+            "label": "The Green Goblin",
+            "deckLists": [
+              {
+                "label": "Risky Business",
+                "deckListId": "Risky Business"
+              },
+              {
+                "label": "Mutagen Formula",
+                "deckListId": "Mutagen Formula"
+              }
+            ]
+          },
+          {
+            "label": "The Rise of Red Skull",
+            "deckLists": [
+              {
+                "label": "Crossbones",
+                "deckListId": "Crossbones"
+              },
+              {
+                "label": "Absorbing Man",
+                "deckListId": "Absorbing Man"
+              },
+              {
+                "label": "Taskmaster",
+                "deckListId": "Taskmaster"
+              },
+              {
+                "label": "Zola",
+                "deckListId": "Zola"
+              },
+              {
+                "label": "Red Skull",
+                "deckListId": "Red Skull"
+              }
+            ]
+          },
+          {
+            "label": "The Wrecking Crew",
+            "deckLists": [
+              {
+                "label": "Wrecking Crew",
+                "deckListId": "Wrecking Crew"
+              },
+              {
+                "label": "Wrecker",
+                "deckListId": "Wrecker"
+              },
+              {
+                "label": "Thunderball",
+                "deckListId": "Thunderball"
+              },
+              {
+                "label": "Piledriver",
+                "deckListId": "Piledriver"
+              },
+              {
+                "label": "Bulldozer",
+                "deckListId": "Bulldozer"
+              }
+            ]
+          },
+          {
+            "label": "The Once and Future Kang",
+            "deckLists": [
+              {
+                "label": "Kang",
+                "deckListId": "Kang"
+              },
+              {
+                "label": "Expert Kang",
+                "deckListId": "Expert Kang"
+              }
+            ]
+          },
+          {
+            "label": "Galaxy's Most Wanted",
+            "deckLists": [
+              {
+                "label": "Brotherhood of Badoon",
+                "deckListId": "Brotherhood of Badoon"
+              },
+              {
+                "label": "Infiltrate the Museum",
+                "deckListId": "Infiltrate the Museum"
+              },
+              {
+                "label": "Escape the Museum",
+                "deckListId": "Escape the Museum"
+              },
+              {
+                "label": "Nebula",
+                "deckListId": "Nebula (Scenario)"
+              },
+              {
+                "label": "Ronan the Accuser",
+                "deckListId": "Ronan the Accuser"
+              }
+            ]
+          },
+          {
+            "label": "The Mad Titan's Shadow",
+            "deckLists": [
+              {
+                "label": "Ebony Maw",
+                "deckListId": "Ebony Maw"
+              },
+              {
+                "label": "Tower Defense",
+                "deckListId": "Tower Defense"
+              },
+              {
+                "label": "Thanos",
+                "deckListId": "Thanos"
+              },
+              {
+                "label": "Hela",
+                "deckListId": "Hela"
+              },
+              {
+                "label": "Loki",
+                "deckListId": "Loki"
+              }
+            ]
+          },
+          {
+            "label": "The Hood",
+            "deckLists": [
+              {
+                "label": "The Hood",
+                "deckListId": "The Hood"
+              }
+            ]
+          },
+          {
+            "label": "Sinister Motives",
+            "deckLists": [
+              {
+                "label": "Sandman",
+                "deckListId": "Sandman"
+              },
+              {
+                "label": "Venom",
+                "deckListId": "Venom (Scenario)"
+              },
+              {
+                "label": "Mysterio",
+                "deckListId": "Mysterio"
+              },
+              {
+                "label": "The Sinister Six",
+                "deckListId": "The Sinister Six"
+              },
+              {
+                "label": "Venom Goblin",
+                "deckListId": "Venom Goblin"
+              }
+            ]
+          },
+          {
+            "label": "Mutant Genesis",
+            "deckLists": [
+              {
+                "label": "Sabretooth",
+                "deckListId": "Sabretooth"
+              },
+              {
+                "label": "Project Wideawake",
+                "deckListId": "Project Wideawake"
+              },
+              {
+                "label": "Master Mold",
+                "deckListId": "Master Mold"
+              },
+              {
+                "label": "Mansion Attack",
+                "deckListId": "Mansion Attack"
+              },
+              {
+                "label": "Magneto",
+                "deckListId": "Magneto"
+              }
+            ]
+          },
+          {
+            "label": "MojoMania",
+            "deckLists": [
+              {
+                "label": "MaGog",
+                "deckListId": "MaGog"
+              },
+              {
+                "label": "Spiral",
+                "deckListId": "Spiral"
+              },
+              {
+                "label": "Mojo",
+                "deckListId": "Mojo"
+              }
+            ]
+          },
+          {
+            "label": "NeXt Evolution",
+            "deckLists": [
+              {
+                "label": "Morlock Siege",
+                "deckListId": "Morlock Siege"
+              },
+              {
+                "label": "On the Run",
+                "deckListId": "On the Run"
+              },
+              {
+                "label": "Juggernaut",
+                "deckListId": "Juggernaut"
+              },
+              {
+                "label": "Mister Sinister",
+                "deckListId": "Mister Sinister"
+              },
+              {
+                "label": "Stryfe",
+                "deckListId": "Stryfe"
+              }
+            ]
+          },
+          {
+            "label": "Age of Apocalypse",
+            "deckLists": [
+              {
+                "label": "Unus",
+                "deckListId": "Unus"
+              },
+              {
+                "label": "Four Horsemen",
+                "deckListId": "Four Horsemen"
+              },
+              {
+                "label": "Apocalypse",
+                "deckListId": "Apocalypse"
+              },
+              {
+                "label": "Dark Beast",
+                "deckListId": "Dark Beast"
+              },
+              {
+                "label": "En Sabah Nur",
+                "deckListId": "En Sabah Nur"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Hero Precons",
+        "deckLists": [
+          {
+            "label": "Spider-Man",
+            "deckListId": "Spider-Man"
+          },
+          {
+            "label": "Captain Marvel",
+            "deckListId": "Captain Marvel"
+          },
+          {
+            "label": "Black Panther",
+            "deckListId": "Black Panther"
+          },
+          {
+            "label": "She-Hulk",
+            "deckListId": "She-Hulk"
+          },
+          {
+            "label": "Iron Man",
+            "deckListId": "Iron Man"
+          },
+          {
+            "label": "Captain America",
+            "deckListId": "Captain America"
+          },
+          {
+            "label": "Hawkeye",
+            "deckListId": "Hawkeye"
+          },
+          {
+            "label": "Spider-Woman",
+            "deckListId": "Spider-Woman"
+          },
+          {
+            "label": "Ms. Marvel",
+            "deckListId": "Ms. Marvel"
+          },
+          {
+            "label": "Thor",
+            "deckListId": "Thor"
+          },
+          {
+            "label": "Black Widow",
+            "deckListId": "Black Widow"
+          },
+          {
+            "label": "Doctor Strange",
+            "deckListId": "Doctor Strange"
+          },
+          {
+            "label": "Hulk",
+            "deckListId": "Hulk"
+          },
+          {
+            "label": "Ant-Man",
+            "deckListId": "Ant-Man"
+          },
+          {
+            "label": "Wasp",
+            "deckListId": "Wasp"
+          },
+          {
+            "label": "Quicksilver",
+            "deckListId": "Quicksilver"
+          },
+          {
+            "label": "Scarlet Witch",
+            "deckListId": "Scarlet Witch"
+          },
+          {
+            "label": "Groot",
+            "deckListId": "Groot"
+          },
+          {
+            "label": "Rocket Raccoon",
+            "deckListId": "Rocket Raccoon"
+          },
+          {
+            "label": "Star-Lord",
+            "deckListId": "Star-Lord"
+          },
+          {
+            "label": "Gamora",
+            "deckListId": "Gamora"
+          },
+          {
+            "label": "Drax",
+            "deckListId": "Drax"
+          },
+          {
+            "label": "Venom",
+            "deckListId": "Venom (Hero)"
+          },
+          {
+            "label": "Spectrum",
+            "deckListId": "Spectrum"
+          },
+          {
+            "label": "Adam Warlock",
+            "deckListId": "Adam Warlock"
+          },
+          {
+            "label": "Nebula",
+            "deckListId": "Nebula (Hero)"
+          },
+          {
+            "label": "War Machine",
+            "deckListId": "War Machine"
+          },
+          {
+            "label": "Valkyrie",
+            "deckListId": "Valkyrie"
+          },
+          {
+            "label": "Vision",
+            "deckListId": "Vision"
+          },
+          {
+            "label": "Ghost-Spider",
+            "deckListId": "Ghost-Spider"
+          },
+          {
+            "label": "Spider-Man (Miles Morales)",
+            "deckListId": "Spider-Man (Miles Morales)"
+          },
+          {
+            "label": "Nova",
+            "deckListId": "Nova"
+          },
+          {
+            "label": "Ironheart",
+            "deckListId": "Ironheart"
+          },
+          {
+            "label": "Spider-Ham",
+            "deckListId": "Spider-Ham"
+          },
+          {
+            "label": "SP\/\/dr",
+            "deckListId": "SP\/\/dr"
+          },
+          {
+            "label": "Colossus",
+            "deckListId": "Colossus"
+          },
+          {
+            "label": "Shadowcat",
+            "deckListId": "Shadowcat"
+          },
+          {
+            "label": "Cyclops",
+            "deckListId": "Cyclops"
+          },
+          {
+            "label": "Phoenix",
+            "deckListId": "Phoenix"
+          },
+          {
+            "label": "Wolverine",
+            "deckListId": "Wolverine"
+          },
+          {
+            "label": "Storm",
+            "deckListId": "Storm"
+          },
+          {
+            "label": "Gambit",
+            "deckListId": "Gambit"
+          },
+          {
+            "label": "Rogue",
+            "deckListId": "Rogue"
+          },
+          {
+            "label": "Cable",
+            "deckListId": "Cable"
+          },
+          {
+            "label": "Domino",
+            "deckListId": "Domino"
+          },
+          {
+            "label": "Psylocke",
+            "deckListId": "Psylocke"
+          },
+          {
+            "label": "Angel",
+            "deckListId": "Angel"
+          },
+          {
+            "label": "X-23",
+            "deckListId": "X-23"
+          },
+          {
+            "label": "Deadpool",
+            "deckListId": "Deadpool"
+          },
+          {
+            "label": "Bishop",
+            "deckListId": "Bishop"
+          },
+          {
+            "label": "Magik",
+            "deckListId": "Magik"
+          }
+        ]
+      },
+      {
+        "label": "Nemesis Sets",
+        "deckLists": [
+          {
+            "label": "Black Panther Nemesis",
+            "deckListId": "Black Panther Nemesis"
+          },
+          {
+            "label": "She-Hulk Nemesis",
+            "deckListId": "She-Hulk Nemesis"
+          },
+          {
+            "label": "Spider-Man Nemesis",
+            "deckListId": "Spider-Man Nemesis"
+          },
+          {
+            "label": "Iron Man Nemesis",
+            "deckListId": "Iron Man Nemesis"
+          },
+          {
+            "label": "Captain Marvel Nemesis",
+            "deckListId": "Captain Marvel Nemesis"
+          },
+          {
+            "label": "Captain America Nemesis",
+            "deckListId": "Captain America Nemesis"
+          },
+          {
+            "label": "Hawkeye Nemesis",
+            "deckListId": "Hawkeye Nemesis"
+          },
+          {
+            "label": "Spider-Woman Nemesis",
+            "deckListId": "Spider-Woman Nemesis"
+          },
+          {
+            "label": "Ms. Marvel Nemesis",
+            "deckListId": "Ms. Marvel Nemesis"
+          },
+          {
+            "label": "Thor Nemesis",
+            "deckListId": "Thor Nemesis"
+          },
+          {
+            "label": "Black Widow Nemesis",
+            "deckListId": "Black Widow Nemesis"
+          },
+          {
+            "label": "Doctor Strange Nemesis",
+            "deckListId": "Doctor Strange Nemesis"
+          },
+          {
+            "label": "Hulk Nemesis",
+            "deckListId": "Hulk Nemesis"
+          },
+          {
+            "label": "Ant-Man Nemesis",
+            "deckListId": "Ant-Man Nemesis"
+          },
+          {
+            "label": "Wasp Nemesis",
+            "deckListId": "Wasp Nemesis"
+          },
+          {
+            "label": "Quicksilver Nemesis",
+            "deckListId": "Quicksilver Nemesis"
+          },
+          {
+            "label": "Scarlet Witch Nemesis",
+            "deckListId": "Scarlet Witch Nemesis"
+          },
+          {
+            "label": "Groot Nemesis",
+            "deckListId": "Groot Nemesis"
+          },
+          {
+            "label": "Rocket Raccoon Nemesis",
+            "deckListId": "Rocket Raccoon Nemesis"
+          },
+          {
+            "label": "Star-Lord Nemesis",
+            "deckListId": "Star-Lord Nemesis"
+          },
+          {
+            "label": "Gamora Nemesis",
+            "deckListId": "Gamora Nemesis"
+          },
+          {
+            "label": "Drax Nemesis",
+            "deckListId": "Drax Nemesis"
+          },
+          {
+            "label": "Venom Nemesis",
+            "deckListId": "Venom Nemesis"
+          },
+          {
+            "label": "Spectrum Nemesis",
+            "deckListId": "Spectrum Nemesis"
+          },
+          {
+            "label": "Adam Warlock Nemesis",
+            "deckListId": "Adam Warlock Nemesis"
+          },
+          {
+            "label": "Nebula Nemesis",
+            "deckListId": "Nebula Nemesis"
+          },
+          {
+            "label": "War Machine Nemesis",
+            "deckListId": "War Machine Nemesis"
+          },
+          {
+            "label": "Valkyrie Nemesis",
+            "deckListId": "Valkyrie Nemesis"
+          },
+          {
+            "label": "Vision Nemesis",
+            "deckListId": "Vision Nemesis"
+          },
+          {
+            "label": "Ghost-Spider Nemesis",
+            "deckListId": "Ghost-Spider Nemesis"
+          },
+          {
+            "label": "Spider-Man Nemesis (Miles Morales)",
+            "deckListId": "Spider-Man Nemesis (Miles Morales)"
+          },
+          {
+            "label": "Nova Nemesis",
+            "deckListId": "Nova Nemesis"
+          },
+          {
+            "label": "Ironheart Nemesis",
+            "deckListId": "Ironheart Nemesis"
+          },
+          {
+            "label": "Spider-Ham Nemesis",
+            "deckListId": "Spider-Ham Nemesis"
+          },
+          {
+            "label": "SP\/\/dr Nemesis",
+            "deckListId": "SP\/\/dr Nemesis"
+          },
+          {
+            "label": "Colossus Nemesis",
+            "deckListId": "Colossus Nemesis"
+          },
+          {
+            "label": "Shadowcat Nemesis",
+            "deckListId": "Shadowcat Nemesis"
+          },
+          {
+            "label": "Cyclops Nemesis",
+            "deckListId": "Cyclops Nemesis"
+          },
+          {
+            "label": "Phoenix Nemesis",
+            "deckListId": "Phoenix Nemesis"
+          },
+          {
+            "label": "Wolverine Nemesis",
+            "deckListId": "Wolverine Nemesis"
+          },
+          {
+            "label": "Storm Nemesis",
+            "deckListId": "Storm Nemesis"
+          },
+          {
+            "label": "Gambit Nemesis",
+            "deckListId": "Gambit Nemesis"
+          },
+          {
+            "label": "Rogue Nemesis",
+            "deckListId": "Rogue Nemesis"
+          },
+          {
+            "label": "Cable Nemesis",
+            "deckListId": "Cable Nemesis"
+          },
+          {
+            "label": "Domino Nemesis",
+            "deckListId": "Domino Nemesis"
+          },
+          {
+            "label": "Psylocke Nemesis",
+            "deckListId": "Psylocke Nemesis"
+          },
+          {
+            "label": "Angel Nemesis",
+            "deckListId": "Angel Nemesis"
+          },
+          {
+            "label": "X-23 Nemesis",
+            "deckListId": "X-23 Nemesis"
+          },
+          {
+            "label": "Deadpool Nemesis",
+            "deckListId": "Deadpool Nemesis"
+          },
+          {
+            "label": "Bishop Nemesis",
+            "deckListId": "Bishop Nemesis"
+          },
+          {
+            "label": "Magik Nemesis",
+            "deckListId": "Magik Nemesis"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/json/functions.json
+++ b/json/functions.json
@@ -375,6 +375,31 @@
         ]
       ]
     },
+    "BUILD_MC4DB_FACE": {
+      "args": ["$CARD_JSON", "$BASE_URL"],
+      "code": [
+        ["PROCESS_MAP", {
+          "name": "$CARD_JSON.name",
+          "type": "$CARD_JSON.type_name",
+          "imageUrl": ["JOIN_STRING", "$BASE_URL", "$CARD_JSON.imagesrc"],
+          "hitPointsFixed": "$CARD_JSON.health",
+          "hitPointsScaling": null,
+          "handSize": "$CARD_JSON.hand_size",
+          "accelerationFixed": null,
+          "accelerationScaling": null,
+          "acceleration": "$CARD_JSON.boost",
+          "amplify": null,
+          "crisis": null,
+          "hazard": null,
+          "nemesisMinion": "false",
+          "permanent": "false",
+          "startingThreatFixed": "$CARD_JSON.threat",
+          "startingThreatScaling": null,
+          "toughness": "false",
+          "victory": null
+        }]
+      ]
+    },
     "TOGGLE_ENCOUNTER_2_DECK": {
       "args": ["$VISIBILITY"],
       "code": [

--- a/json/hotkeys.json
+++ b/json/hotkeys.json
@@ -24,7 +24,8 @@
       {"key": "Shift+S", "actionList": "shadowsOfThePast", "label": "id:shadowsOfThePast"},
       {"key": "Shift+P", "actionList": "playerEndPhase", "label": "id:playerEndPhase"},
       {"key": "V", "actionList": "villainEncounterPhase", "label": "id:villainEncounterPhase"},
-      {"key": "Shift+V", "actionList": "villainEndPhase", "label": "id:villainEndPhase"}
+      {"key": "Shift+V", "actionList": "villainEndPhase", "label": "id:villainEndPhase"},
+      {"key": "Ctrl+K", "actionList": ["PROMPT", "$PLAYER_N", "importMc4dbDeck"], "label": "Import Deck from mc4db"}
     ],
     "card": [
       {"key": "A", "actionList": "toggleExhaust", "label": "id:exhaustReady"},

--- a/json/preBuiltDecks(4).json
+++ b/json/preBuiltDecks(4).json
@@ -1,0 +1,26346 @@
+{
+  "preBuiltDecks": {
+    "Kree Fanatic": {
+      "label": "Kree Fanatic",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f18e9be-240c-54c5-860e-9b9d1a038314",
+          "_name": "Ronan the Accuser"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c115af60-c59c-5ce0-aea9-79617c62e205",
+          "_name": "Judge, Jury, Executioner"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ee0c60cd-927d-5eb6-a576-d7ac4a2e03e9",
+          "_name": "The Accused"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ce28e7b4-a1ee-53dc-bd53-adbae130a78d",
+          "_name": "Bring the Hammer Down"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f8877fd3-cfb6-5029-ad8d-d5b165789934",
+          "_name": "\"You Dare Oppose Me?\""
+        }
+      ]
+    },
+    "Spider-Man": {
+      "label": "Spider-Man",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "c92a3f54-6113-5ef4-8a82-f8a366cf499c",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5a597d72-8f94-5cf0-b84b-5253bc374302",
+          "_name": "Black Cat"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d4f6535b-a0f4-5ef1-b778-509329bc5b69",
+          "_name": "Backflip"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c52b7e43-bd94-55ae-889e-ea8205dfd3f2",
+          "_name": "Enhanced Spider-Sense"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c6999c64-b8e0-5929-9670-305d675b99ba",
+          "_name": "Swinging Web Kick"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0456bb15-b045-5a89-8c50-adc4d7b6fa33",
+          "_name": "Aunt May"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3115548d-e6ce-5d78-a259-f828481f7887",
+          "_name": "Spider-Tracer"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "73027f2b-119d-5f3e-9049-0fb9aff7f0ce",
+          "_name": "Web-Shooter"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3ecc9de6-866a-5ece-b614-128cd6be6296",
+          "_name": "Webbed Up"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "36cb7913-e1d4-585c-8cc5-38752cf2fe00",
+          "_name": "Daredevil"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "96cb6425-1f73-5849-b6f3-69cdd718ab48",
+          "_name": "For Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "26edcf96-51be-5844-b02e-06b60c4d91ce",
+          "_name": "Great Responsibility"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5d841847-94a8-5ff4-968a-fdbe5d4af9cd",
+          "_name": "Heroic Intuition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ec687afd-f821-5770-b1e8-97301d70a258",
+          "_name": "Interrogation Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3e593704-d029-5355-a31a-89f7b1744f6a",
+          "_name": "Jessica Jones"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "560cbe53-74a5-5338-bab9-5dbdb8cbfe02",
+          "_name": "Surveillance Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "beba6d45-629f-55c9-94cf-3568c144eb6b",
+          "_name": "The Power of Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb60e771-7bc6-55f1-a483-8e8bbd69c447",
+          "_name": "Emergency"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eea92148-a9d4-5e1f-a7db-3da265cabfbf",
+          "_name": "Haymaker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a0165626-0a00-5343-9184-3cf44aaa8941",
+          "_name": "Nick Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1a729a71-3a95-530e-ab3d-137c978eda8e",
+          "_name": "Tenacity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "76fc3fac-9453-599b-83f3-2ee7bdba01c0",
+          "_name": "Eviction Notice"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a44fff25-a7bf-5c09-a4cd-056efe983e37",
+          "_name": "Highway Robbery"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "40288e53-42ee-556c-952a-9b38a8124379",
+          "_name": "Vulture"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0c745dcf-71ba-5321-b883-4f3fd62b10d2",
+          "_name": "Sweeping Swoop"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d9a2dba5-2f0b-5062-99d5-6101a409ed39",
+          "_name": "The Vulture's Plans"
+        }
+      ]
+    },
+    "Captain Marvel": {
+      "label": "Captain Marvel",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "453a3be5-1741-5491-a2b1-c93debc1c0ca",
+          "_name": "Captain Marvel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "aff2ecd0-fc0e-55cf-8fe1-382be90b135c",
+          "_name": "Spider-Woman"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "663499a0-8378-557b-b068-fb4656f4e374",
+          "_name": "Crisis Interdiction"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "101706a2-7839-5333-87da-2fcafadf5bd3",
+          "_name": "Photonic Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "182585c7-4606-50c3-a9bc-6c87d5cb0289",
+          "_name": "Energy Absorption"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4e9daa50-1644-509a-945c-6c860fcfa79f",
+          "_name": "Alpha Flight Station"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2e5a3ea5-eb32-50be-9bb9-26c5e2f1dbd5",
+          "_name": "Captain Marvel's Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5dfa61bb-02e9-50ca-89a0-d1f3af88e378",
+          "_name": "Cosmic Flight"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a79998ad-e35f-5d1b-b35f-cfaf0dabc42b",
+          "_name": "Energy Channel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d6cd8844-cc7b-5ef8-9885-712b3b0baf80",
+          "_name": "Get Ready"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "78a441a9-d7e9-57ad-9377-3e6e7278b4d3",
+          "_name": "Hawkeye"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "717e6686-d007-5acb-a9a2-d2ac766f0930",
+          "_name": "Inspired"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2da8638a-9879-5094-8d84-66e6b7692dd7",
+          "_name": "Lead From the Front"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ced1d16c-ccfd-59e3-9547-911ff77521a7",
+          "_name": "Make the Call"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "48399019-8ff4-5375-8d1f-c3310f8888f0",
+          "_name": "Maria Hill"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "04fe3e79-279a-5d4b-93f4-bf6fa562e825",
+          "_name": "The Power of Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f04f4978-152b-50ca-ab0d-9d1d57686295",
+          "_name": "The Triskelion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3ad06a64-420b-5f9b-8ea6-7c90149c3d5c",
+          "_name": "Vision"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb60e771-7bc6-55f1-a483-8e8bbd69c447",
+          "_name": "Emergency"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eea92148-a9d4-5e1f-a7db-3da265cabfbf",
+          "_name": "Haymaker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a0165626-0a00-5343-9184-3cf44aaa8941",
+          "_name": "Nick Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1a729a71-3a95-530e-ab3d-137c978eda8e",
+          "_name": "Tenacity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "038d9eb4-dcaf-59ad-98d5-2b56dd54909f",
+          "_name": "Family Emergency"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "196a9d70-ff93-5d7e-8b65-a3c3a027846a",
+          "_name": "The Psyche-Magnitron"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "20498295-0c47-59ae-8e15-987247906d7b",
+          "_name": "Yon-Rogg"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "87bec687-5f1c-5082-99e8-11fa81996b4a",
+          "_name": "Kree Manipulator"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cd6328e7-2acc-5d3e-86f8-c41c189bdc26",
+          "_name": "Yon-Rogg's Treason"
+        }
+      ]
+    },
+    "Rhino": {
+      "label": "Rhino",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "16f27f91-8904-5ecd-9985-1a23dc866d1c",
+          "_name": "Enhanced Ivory Horn"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ad69696c-7e2e-5c2d-a9bf-30d5eb4cf293",
+          "_name": "Hydra Mercenary"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7a02653d-417b-5506-9007-6130a0bffea4",
+          "_name": "Sandman"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "662ac097-f391-5e7c-9cce-9dc8c46c057f",
+          "_name": "Shocker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8c86eec0-b5a0-563c-8225-a9f302de8ec7",
+          "_name": "Hard to Keep Down"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "067d843c-6a6f-553f-b834-421977a7659d",
+          "_name": "\"I'm Tough!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "2d1d1add-55c7-5a09-ae01-5235f492cf34",
+          "_name": "Stampede"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89399b59-bb97-5eef-81f5-7bf8c8194b15",
+          "_name": "Breakin' & Takin'"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "29ee503b-df5b-51b4-a23b-94b9ca65d67d",
+          "_name": "Crowd Control"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d409eee6-31cd-5b41-9863-6379c293ad5f",
+          "_name": "Rhino"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "fe31694e-7d87-5c7c-b20d-8765a4dabee0",
+          "_name": "Rhino"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d1f87fc5-f4f4-5600-837f-d44b0a645eba",
+          "_name": "Rhino"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "53f44777-cf8a-565d-bd34-6c9657c47bce",
+          "_name": "The Break-In!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "36766d3d-dba1-5799-87ef-ea9ed2c5fb20",
+          "_name": "Armored Rhino Suit"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b62ab98d-4027-56cd-9114-d02db335aac2",
+          "_name": "Charge"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Rhino"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "DEFINE",
+              "$CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "89399b59-bb97-5eef-81f5-7bf8c8194b15"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "sharedVillain",
+              -1
+            ],
+            [
+              "INCREASE_VAL",
+              "/cardById/$CARD.id/tokens/threat",
+              "$GAME.numPlayers"
+            ]
+          ]
+        ]
+      ]
+    },
+    "Bomb Scare": {
+      "label": "Bomb Scare",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7d08b829-a72c-5475-a4c7-b5c383b65494",
+          "_name": "Bomb Scare"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b50d78d6-b5a2-5d5c-bfe8-514808c3a29e",
+          "_name": "Hydra Bomber"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "461a921e-f4f4-5ce1-a1fe-6a6d8454c4e7",
+          "_name": "Explosion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9f448db8-d667-5e7a-a612-4321c446a0f7",
+          "_name": "False Alarm"
+        }
+      ]
+    },
+    "Klaw": {
+      "label": "Klaw",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f59789a1-9f97-5189-a4cb-b62aa0005691",
+          "_name": "Klaw"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "276a2c25-c1f0-5715-9d78-27dfc03ea54d",
+          "_name": "Klaw"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "6ad69b49-ce13-5cdd-9e1a-838b710c744e",
+          "_name": "Klaw"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "23d565d5-af0f-50c1-a1c2-5bb413502d04",
+          "_name": "Underground Distribution"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "dfb829ff-8d12-56d0-9fb6-c50dcacdb28c",
+          "_name": "Secret Rendezvous"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2ccee51b-95b1-50b2-a164-63e2194c391a",
+          "_name": "Sonic Converter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5ed5f5da-1e33-58d3-a1c8-2c90320a4a0b",
+          "_name": "Solid-Sound Body"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "8fb8f34d-78d4-549c-a00f-a91dcf38b193",
+          "_name": "Armored Guard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ab74c5db-d3b8-54e8-9175-39fe997297e7",
+          "_name": "Weapons Runner"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "594ddea2-2363-5a78-a70b-629bb98166ea",
+          "_name": "Klaw's Vengeance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "20f5b6e8-5df8-57b7-89b0-ada41bb8391c",
+          "_name": "Sonic Boom"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c3359deb-ee46-5305-bc04-b06bc7affba4",
+          "_name": "Sound Manipulation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c69766b1-a6a4-5338-a96e-5dfe1e787e70",
+          "_name": "Defense Network"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "450c7ad3-1515-57ce-80cc-629b572b889a",
+          "_name": "Illegal Arms Factory"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "72f3607e-5488-5c3a-be65-24d8ce749d90",
+          "_name": "The \"Immortal\" Klaw"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Klaw"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "DEFINE",
+          "$CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "c69766b1-a6a4-5338-a96e-5dfe1e787e70"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$CARD.id",
+          "sharedVillain",
+          0
+        ],
+        [
+          "INCREASE_VAL",
+          "/cardById/$CARD.id/tokens/threat",
+          "$GAME.numPlayers"
+        ],
+        [
+          "ACTION_LIST",
+          "discardMinion"
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "DEFINE",
+              "$CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "72f3607e-5488-5c3a-be65-24d8ce749d90"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "sharedVillain",
+              0
+            ],
+            [
+              "LOG",
+              "{{$CARD.sides.A.name}} increases villain health by 10."
+            ],
+            [
+              "DEFINE",
+              "$INCREASE_HIT_POINTS",
+              10
+            ]
+          ]
+        ]
+      ]
+    },
+    "Masters of Evil": {
+      "label": "Masters of Evil",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e9f795f0-4d7f-5ff9-8faa-3edd58c1a131",
+          "_name": "The Masters of Evil"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a99cb606-466e-5768-a121-994535002b90",
+          "_name": "Radioactive Man"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "233eb938-6120-5193-8cba-68adff018df7",
+          "_name": "Whirlwind"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e7f59f60-0f6f-5f1c-88fb-8cd543673073",
+          "_name": "Tiger Shark"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eb0962c4-fcad-5b8e-8b2e-28c8fe552827",
+          "_name": "Melter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9f9a9ee2-aa22-5583-b87b-5d5e88e5cce2",
+          "_name": "Masters of Mayhem"
+        }
+      ]
+    },
+    "Ultron": {
+      "label": "Ultron",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f90e9b22-5fcb-57ca-81b2-cfb868c882a8",
+          "_name": "Ultron"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f6d0beaf-c89d-5e40-bb62-87b0dadf73c3",
+          "_name": "Ultron"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f2d327a4-8647-55d7-8cf0-3b5958a2d766",
+          "_name": "Ultron"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "fb5b0399-50de-52e9-9ba3-42b9eae95267",
+          "_name": "The Crimson Cowl"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "102656e2-9d1c-5302-b0b8-1ce122e106b9",
+          "_name": "Assault on NORAD"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "da4df87c-6ac7-57cc-a5b0-5b7eaa4dbbe1",
+          "_name": "Countdown to Oblivion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8dc89688-080f-55ec-a557-c469bc9b4705",
+          "_name": "Ultron Drones"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "53ee2091-bcd9-5458-9b4e-12002d2fb113",
+          "_name": "Program Transmitter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8b1f2459-0e82-52ad-bcdf-9d5c8ec01288",
+          "_name": "Upgraded Drones"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "e3bd93ef-0643-558e-9d2d-d35fa38664ac",
+          "_name": "Advanced Ultron Drone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ee1ed1f5-9ede-54c8-b653-333250a1aec0",
+          "_name": "Android Efficiency"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e6e9dd84-24a3-5f10-a995-947430ca8876",
+          "_name": "Android Efficiency"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e10baa4e-e7ee-56b6-928f-427d4f616457",
+          "_name": "Android Efficiency"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "90986110-9b5e-59ac-9ff1-e434b73faacd",
+          "_name": "Rage of Ultron"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9b3f1734-9b46-57ab-8eed-645ddbf7a0c1",
+          "_name": "Repair Sequence"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ff31bd49-773f-57be-ad3b-c0e28ea51812",
+          "_name": "Swarm Attack"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3cb4fe25-b0e4-5b87-b89a-a8da28307a78",
+          "_name": "Drone Factory"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "188d4fc9-689a-5ec8-8c33-78607a1e521d",
+          "_name": "Invasive AI"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5f40a32e-118b-5b1c-9000-d5e8f6f8ba5a",
+          "_name": "Ultron's Imperative"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Ultron"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "DEFINE",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "8dc89688-080f-55ec-a557-c469bc9b4705"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "LOG",
+          "Setup: Deal each player a drone minion"
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$PLAYER_N",
+          "$PLAYER_ORDER",
+          [
+            [
+              "DEFINE",
+              "$CARD",
+              "$GAME.groupById.{{$PLAYER_N}}Deck.parentCards.[0]"
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "{{$PLAYER_N}}Engaged",
+              -1
+            ],
+            [
+              "SET",
+              "/cardById/$CARD.id/currentSide",
+              "B"
+            ]
+          ]
+        ]
+      ]
+    },
+    "Under Attack": {
+      "label": "Under Attack",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "53e4fdb4-6888-5351-b297-498285d36c3f",
+          "_name": "Under Attack"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af2a0ce9-dc62-5e85-b02d-88eea7412c6e",
+          "_name": "Vibranium Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b6048f64-f3a1-5635-8c75-72fe67e4d6a7",
+          "_name": "Concussion Blasters"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "29661103-0fbc-55ba-929e-292d4a695e05",
+          "_name": "Concussive Blast"
+        }
+      ]
+    },
+    "Black Panther": {
+      "label": "Black Panther",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "d3952869-1bf8-57c4-b9fb-b6834a2dc365",
+          "_name": "Black Panther"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eddf8866-e463-5380-8975-eff7dbf14c83",
+          "_name": "Shuri"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8a8133a1-5234-5e26-a4f1-cf8a401e2c5c",
+          "_name": "Ancestral Knowledge"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9e8d8474-3721-5ad9-b830-0b722a70193c",
+          "_name": "Wakanda Forever!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "38f8f7b3-8787-5563-bdbb-e8511044b7ae",
+          "_name": "Wakanda Forever!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b9396f65-c1f1-539b-a3e7-743c1073c70f",
+          "_name": "Wakanda Forever!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b3da0d8e-52e1-5427-afa9-1b7b71fb3ee2",
+          "_name": "Wakanda Forever!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f034f630-df56-5319-89b1-c0e8f4829328",
+          "_name": "Vibranium Resource"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "defcd232-730d-5f06-9d95-f5b14f196cb3",
+          "_name": "The Golden City"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1b34bd1a-3faa-525c-88d0-e008303b45b0",
+          "_name": "Energy Daggers"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4df66eb0-1e8c-5a5d-8ba5-0db273c86e7c",
+          "_name": "Panther Claws"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "33ed66a3-5f90-5e7e-bc65-dfd3201ca83c",
+          "_name": "Tactical Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4234dab4-636c-5546-b9e4-7f30b02ee7f2",
+          "_name": "Vibranium Suit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b264b5f8-4830-5fc0-a35d-b011f005ece2",
+          "_name": "Armored Vest"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2047bb74-8633-59cd-9f41-ad8edf7ce5ad",
+          "_name": "Black Widow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b90b259b-916b-5e38-b454-929125397d2c",
+          "_name": "Counter-Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a793780e-eb17-530b-8723-c7c295f0fe3e",
+          "_name": "Get Behind Me!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bd2f6e16-7074-5a7f-9519-ced58f280310",
+          "_name": "Indomitable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b33de9ce-6d3d-5246-9181-d9b5ded40819",
+          "_name": "Luke Cage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d52cd91a-ee3d-5021-b735-d54dfe3ff9c8",
+          "_name": "Med Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4f8dd69d-4555-5af5-b48f-709a73d6acea",
+          "_name": "The Power of Protection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb60e771-7bc6-55f1-a483-8e8bbd69c447",
+          "_name": "Emergency"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eea92148-a9d4-5e1f-a7db-3da265cabfbf",
+          "_name": "Haymaker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a0165626-0a00-5343-9184-3cf44aaa8941",
+          "_name": "Nick Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1a729a71-3a95-530e-ab3d-137c978eda8e",
+          "_name": "Tenacity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6f4fc111-1227-5b50-afd7-d34bbece6c4e",
+          "_name": "Affairs of State"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f2da76be-01fc-5e4b-9f83-0f65a4ae23f1",
+          "_name": "Usurp the Throne"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b7f17901-4c4d-598e-b244-c8f04bab4b7d",
+          "_name": "Killmonger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "baa3f8c1-cd1d-5ad9-9fb7-49d3f4db8a0c",
+          "_name": "Heart-Shaped Herb"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "a809331b-5b5c-5d14-8a03-522f4b5de635",
+          "_name": "Ritual Combat"
+        }
+      ]
+    },
+    "Black Panther Nemesis": {
+      "label": "Black Panther Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f2da76be-01fc-5e4b-9f83-0f65a4ae23f1",
+          "_name": "Usurp the Throne"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b7f17901-4c4d-598e-b244-c8f04bab4b7d",
+          "_name": "Killmonger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "baa3f8c1-cd1d-5ad9-9fb7-49d3f4db8a0c",
+          "_name": "Heart-Shaped Herb"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "a809331b-5b5c-5d14-8a03-522f4b5de635",
+          "_name": "Ritual Combat"
+        }
+      ]
+    },
+    "She-Hulk": {
+      "label": "She-Hulk",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "b90a942c-221e-515d-8f6a-1b927049298f",
+          "_name": "She-Hulk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e804778b-d55a-504f-8afa-50d5052c92e1",
+          "_name": "Hellcat"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6fe4edae-253b-57b2-9189-3aa4522a4abc",
+          "_name": "Gamma Slam"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a9f9047a-6651-52be-ad06-b41dda09753a",
+          "_name": "Ground Stomp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3a125cfa-c3ed-56e8-8832-786c38c74189",
+          "_name": "Legal Practice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "15e9ffe8-3d07-5345-8263-a94048f1d5e4",
+          "_name": "One-Two Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4f967490-980f-52a7-ab43-043fc98a2715",
+          "_name": "Split Personality"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d235a070-197c-5d0c-8b0b-4c853cea629c",
+          "_name": "Superhuman Law Division"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8ed54874-bd83-583a-ae84-7bea1b4bd5a2",
+          "_name": "Focused Rage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bbb9d9c2-1bf8-5486-8c9e-27a523a5ba56",
+          "_name": "Superhuman Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b7b48c3f-99e2-5e32-82b5-3f6f7b955781",
+          "_name": "Chase Them Down"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3c8506e5-d29c-5c9c-81b8-ee0f47e91ea0",
+          "_name": "Combat Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a16ca343-ed91-5aaf-b3bb-73036052fbb1",
+          "_name": "Hulk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a6671bdc-87c8-5d93-bb74-ef3f4c748e43",
+          "_name": "Relentless Assault"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8e5f35a0-59e2-56de-ba10-903315e2615b",
+          "_name": "Tac Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "904aed79-f923-59e8-a469-960dfe1aa330",
+          "_name": "Tigra"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "52ce4abf-f0bb-5144-ad68-4b27917d65e6",
+          "_name": "Uppercut"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb60e771-7bc6-55f1-a483-8e8bbd69c447",
+          "_name": "Emergency"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eea92148-a9d4-5e1f-a7db-3da265cabfbf",
+          "_name": "Haymaker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a0165626-0a00-5343-9184-3cf44aaa8941",
+          "_name": "Nick Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1a729a71-3a95-530e-ab3d-137c978eda8e",
+          "_name": "Tenacity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0b283953-807a-5dee-bc9d-04d95bf89fd3",
+          "_name": "Legal Work"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "41e2ac26-891a-57d1-a459-3f735a6c76cd",
+          "_name": "Personal Challenge"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ef79cb43-c539-56be-8dcc-7049461e7509",
+          "_name": "Titania"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6d0678c5-e0c4-5d34-8cd6-3c3e481f6d2a",
+          "_name": "Genetically Enhanced"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "03d696bb-d3ac-592d-9600-a19b7f8be060",
+          "_name": "Titania's Fury"
+        }
+      ]
+    },
+    "She-Hulk Nemesis": {
+      "label": "She-Hulk Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "41e2ac26-891a-57d1-a459-3f735a6c76cd",
+          "_name": "Personal Challenge"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ef79cb43-c539-56be-8dcc-7049461e7509",
+          "_name": "Titania"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6d0678c5-e0c4-5d34-8cd6-3c3e481f6d2a",
+          "_name": "Genetically Enhanced"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "03d696bb-d3ac-592d-9600-a19b7f8be060",
+          "_name": "Titania's Fury"
+        }
+      ]
+    },
+    "Spider-Man Nemesis": {
+      "label": "Spider-Man Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a44fff25-a7bf-5c09-a4cd-056efe983e37",
+          "_name": "Highway Robbery"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "40288e53-42ee-556c-952a-9b38a8124379",
+          "_name": "Vulture"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0c745dcf-71ba-5321-b883-4f3fd62b10d2",
+          "_name": "Sweeping Swoop"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d9a2dba5-2f0b-5062-99d5-6101a409ed39",
+          "_name": "The Vulture's Plans"
+        }
+      ]
+    },
+    "Iron Man": {
+      "label": "Iron Man",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "7050bee0-051f-5b81-9b35-80a294d032df",
+          "_name": "Iron Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4a95d076-1446-5fef-881b-424be216878a",
+          "_name": "War Machine"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "17e02573-8678-51c6-a4c3-ee302832962d",
+          "_name": "Repulsor Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2f01208e-4586-5117-ac10-4449a8f5eb99",
+          "_name": "Supersonic Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3175a974-cb51-5764-b4f5-0475ff8a915e",
+          "_name": "Pepper Potts"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f1606c95-8de1-5bef-8b8e-24bf0a1120c9",
+          "_name": "Stark Tower"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "44759502-628c-5165-9e32-2d9edbcb4d63",
+          "_name": "Arc Reactor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "52fc993f-ad9f-5908-9dd2-305b1861d2ab",
+          "_name": "Mark V Armor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "76620371-945a-5cd5-9ab7-d4e2d8a36f9d",
+          "_name": "Mark V Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "f7cbdb8c-85cf-58d8-b711-5c97912c6915",
+          "_name": "Powered Gauntlets"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8f555eec-8405-52af-8d54-be22619e718e",
+          "_name": "Rocket Boots"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b7b48c3f-99e2-5e32-82b5-3f6f7b955781",
+          "_name": "Chase Them Down"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3c8506e5-d29c-5c9c-81b8-ee0f47e91ea0",
+          "_name": "Combat Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a16ca343-ed91-5aaf-b3bb-73036052fbb1",
+          "_name": "Hulk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a6671bdc-87c8-5d93-bb74-ef3f4c748e43",
+          "_name": "Relentless Assault"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8e5f35a0-59e2-56de-ba10-903315e2615b",
+          "_name": "Tac Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "904aed79-f923-59e8-a469-960dfe1aa330",
+          "_name": "Tigra"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "52ce4abf-f0bb-5144-ad68-4b27917d65e6",
+          "_name": "Uppercut"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb60e771-7bc6-55f1-a483-8e8bbd69c447",
+          "_name": "Emergency"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eea92148-a9d4-5e1f-a7db-3da265cabfbf",
+          "_name": "Haymaker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a0165626-0a00-5343-9184-3cf44aaa8941",
+          "_name": "Nick Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1a729a71-3a95-530e-ab3d-137c978eda8e",
+          "_name": "Tenacity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "99f7c301-230d-502c-b70f-a3f5639e0fc3",
+          "_name": "Business Problems"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3759d8cb-8447-50ed-95ff-076afde556fb",
+          "_name": "Imminent Overload"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b56e5bea-6732-5290-9233-a7b12ebc0de6",
+          "_name": "Whiplash"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "49e6e3a7-12ad-52ad-82b8-a906e06cbe1c",
+          "_name": "Electric Whip Attack"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e095eab-f3d6-5148-957f-331531eb572f",
+          "_name": "Electromagnetic Backlash"
+        }
+      ]
+    },
+    "Iron Man Nemesis": {
+      "label": "Iron Man Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3759d8cb-8447-50ed-95ff-076afde556fb",
+          "_name": "Imminent Overload"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b56e5bea-6732-5290-9233-a7b12ebc0de6",
+          "_name": "Whiplash"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "49e6e3a7-12ad-52ad-82b8-a906e06cbe1c",
+          "_name": "Electric Whip Attack"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e095eab-f3d6-5148-957f-331531eb572f",
+          "_name": "Electromagnetic Backlash"
+        }
+      ]
+    },
+    "Captain Marvel Nemesis": {
+      "label": "Captain Marvel Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "196a9d70-ff93-5d7e-8b65-a3c3a027846a",
+          "_name": "The Psyche-Magnitron"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "20498295-0c47-59ae-8e15-987247906d7b",
+          "_name": "Yon-Rogg"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "87bec687-5f1c-5082-99e8-11fa81996b4a",
+          "_name": "Kree Manipulator"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cd6328e7-2acc-5d3e-86f8-c41c189bdc26",
+          "_name": "Yon-Rogg's Treason"
+        }
+      ]
+    },
+    "Legions of Hydra": {
+      "label": "Legions of Hydra",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4355ac3d-c683-56b2-9072-63efc2185fd5",
+          "_name": "Legions of Hydra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ece93ded-b490-5d34-b9e8-47049e032935",
+          "_name": "Madame Hydra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        }
+      ]
+    },
+    "The Doomsday Chair": {
+      "label": "The Doomsday Chair",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a5672cb7-a84f-5a90-8fc3-519875a01b49",
+          "_name": "The Doomsday Chair"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "98b20e6b-64dd-593d-923c-1d9ee4d8511a",
+          "_name": "MODOK"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "31588b3c-b7a5-5612-b9ef-271a9fe8d956",
+          "_name": "Biomechanical Upgrades"
+        }
+      ]
+    },
+    "Standard": {
+      "label": "Standard",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6d8cfcf4-7827-5344-8fd9-5fa8ede2fd2c",
+          "_name": "Advance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f19bb77a-2450-5beb-ae3a-52b0cd680217",
+          "_name": "Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6ab0790a-4b0c-578b-a2a7-b450da3fd794",
+          "_name": "Caught Off Guard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1aa1cfca-cf54-5b22-bcb3-37c6ad561764",
+          "_name": "Gang-Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "469b291f-931e-5546-a5e0-9b67f931cb7a",
+          "_name": "Shadow of the Past"
+        }
+      ]
+    },
+    "Expert": {
+      "label": "Expert",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0861aa2d-0562-5130-844a-2c18788c49d5",
+          "_name": "Exhaustion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8e6e5467-621a-58f6-b34f-8ceea72b409a",
+          "_name": "Masterplan"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e474af13-54a1-5d10-8b6b-84cf1210a353",
+          "_name": "Under Fire"
+        }
+      ]
+    },
+    "Risky Business": {
+      "label": "Risky Business",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "46d204b0-8f8a-5abe-a136-8f5f2ff6a570",
+          "_name": "Hired Gun"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "bda5f480-96a9-50ce-839b-19c09723eca1",
+          "_name": "Private Security Specialist"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1cd8e9d8-f2ad-51e5-a0dc-5e62505ab571",
+          "_name": "Collapsing Bridge"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5b3e2c83-dfb5-5f14-9722-68aa9ad99cf0",
+          "_name": "Oscorp Manufacturing"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f91e5901-26d1-5c74-8c04-db009b909286",
+          "_name": "Payoff"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "04537d44-59e5-59a9-80d6-4b16a691f5df",
+          "_name": "All in a Day's Work"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7eb5d63d-5464-5e94-b691-934385605eb0",
+          "_name": "Mad Genius"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "dcc99819-ed53-58be-a929-1f4f4bd554dd",
+          "_name": "Norman Osborn"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c6de29e2-df33-5650-b84d-0c2be42a3efb",
+          "_name": "Norman Osborn"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7629227c-ba94-5d32-a19f-caeeedb3e352",
+          "_name": "Norman Osborn"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "48914f18-980a-5030-ae34-feceeaf71c40",
+          "_name": "Hostile Takeover"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "5bf6a478-3e03-551a-93d7-4ab48fea2b12",
+          "_name": "Corporate Acquisition"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "011608d6-475c-5b13-baa2-9572a44cd4d5",
+          "_name": "Criminal Enterprise"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Risky Business"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "DEFINE",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "011608d6-475c-5b13-baa2-9572a44cd4d5"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "SET",
+          "/cardById/$ENV_CARD.id/tokens/generic",
+          [
+            "MULTIPLY",
+            2,
+            "$GAME.numPlayers"
+          ]
+        ]
+      ]
+    },
+    "Mutagen Formula": {
+      "label": "Mutagen Formula",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "557902a0-0a37-594f-82fa-642bad19e5d9",
+          "_name": "Green Goblin"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "24f046c9-6f02-51c4-9637-470cac17b58d",
+          "_name": "Green Goblin"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "5f8ccd29-9a0c-5f36-be76-d5f099200982",
+          "_name": "Green Goblin"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "edb7eaeb-383c-5b59-b28f-bbf082827b67",
+          "_name": "Unleashing the Mutagen"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "723b5842-7d9b-5117-a85d-039c7aa6d146",
+          "_name": "Mutagen Cloud"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "91cf65ed-34da-5418-ba47-f634177ea631",
+          "_name": "Goblin Glider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "16432776-2b04-58dd-8801-4a4efa016b6a",
+          "_name": "Hysteria"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2892c8a9-8c90-5ed5-bdb6-ef7a2300097e",
+          "_name": "Pumpkin Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f0d9c969-430f-5d4a-aa85-a106a35a0643",
+          "_name": "Goblin Knight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "a8b933f8-b9b6-5248-bdda-fcd3bf3aae58",
+          "_name": "Goblin Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 6,
+          "databaseId": "dee50ad3-51e8-5e8e-bc4c-2ff8dfe60af9",
+          "_name": "Goblin Thrall"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e8b19668-f09f-5023-9df0-08e0a0e01001",
+          "_name": "Monster"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3e22f4d8-14be-5232-839d-5c607f30f8ed",
+          "_name": "Goblin Reinforcements"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0c4ea3db-0f49-58e7-afef-77c3203a6dc7",
+          "_name": "Goblin Nation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c56fb7ea-7d6a-559e-b538-5f5d0b0563ff",
+          "_name": "Overrun"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5fd76a01-48be-5121-8bab-2bb6f13febea",
+          "_name": "Death from Above"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "de8d6c86-38b5-5b0f-91c2-491c64455b92",
+          "_name": "I See You"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4133cda5-afe7-5f15-9d32-fa50fed44cf7",
+          "_name": "Overconfidence"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b661a144-fbad-5242-b08d-f8b7f9df4fcc",
+          "_name": "Wicked Ambitions"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Mutagen Formula"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Every player gets a Goblin Thrall"
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$PLAYER_N",
+          "$PLAYER_ORDER",
+          [
+            [
+              "DEFINE",
+              "$MINION_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "AND",
+                  [
+                    "EQUAL",
+                    "$CARD.databaseId",
+                    "dee50ad3-51e8-5e8e-bc4c-2ff8dfe60af9"
+                  ],
+                  [
+                    "EQUAL",
+                    "$CARD.groupId",
+                    "sharedEncounterDeck"
+                  ]
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$MINION_CARD.id",
+              "{{$PLAYER_N}}Engaged",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Every player gets 2 encounter cards."
+            ],
+            [
+              "FOR_EACH_VAL",
+              "$PLAYER_N",
+              "$PLAYER_ORDER",
+              [
+                [
+                  "ACTION_LIST",
+                  "dealEncounterFacedown"
+                ],
+                [
+                  "ACTION_LIST",
+                  "dealEncounterFacedown"
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    },
+    "Goblin Gimmicks": {
+      "label": "Goblin Gimmicks",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "91cf65ed-34da-5418-ba47-f634177ea631",
+          "_name": "Goblin Glider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2892c8a9-8c90-5ed5-bdb6-ef7a2300097e",
+          "_name": "Pumpkin Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d9c28195-36ae-58fc-929d-86d36e8dc038",
+          "_name": "Intimidation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "179fbff2-0685-5da4-a868-f1a2d17edf70",
+          "_name": "Regenerative Healing"
+        }
+      ]
+    },
+    "A Mess of Things": {
+      "label": "A Mess of Things",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0ec07d80-2d40-5401-8d44-a007748bd5c7",
+          "_name": "A Mess of Things"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f1f58868-effa-59fc-b11f-2967e6e903b1",
+          "_name": "Scorpion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1aa1cfca-cf54-5b22-bcb3-37c6ad561764",
+          "_name": "Gang-Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a8598eb7-368b-559d-b37f-6db1d3202a6c",
+          "_name": "Tail Sweep"
+        }
+      ]
+    },
+    "Power Drain": {
+      "label": "Power Drain",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1cbc0491-43d5-5a39-bbf3-bc49defc8697",
+          "_name": "Power Drain"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8a75d995-d5d4-5f3d-a29a-5b12f7f11203",
+          "_name": "Electro"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "67c3003d-0b08-58a4-8cdc-9d3602ca83b9",
+          "_name": "Electromagnetic Pulse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f6f81d93-3559-5f27-878c-41064e3cc796",
+          "_name": "Lightning Bolt"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "65a865d6-4e50-5b14-92ea-949ae672b8ef",
+          "_name": "Shock Therapy"
+        }
+      ]
+    },
+    "Running Interference": {
+      "label": "Running Interference",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4997c996-44c9-59a1-9d8c-be80aa94b42d",
+          "_name": "Running Interference"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bdabf21a-b216-5138-ac19-9df2a3db58e1",
+          "_name": "Tombstone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c9784574-b173-5572-b52b-abb1280e93fc",
+          "_name": "All Tied Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b0f99aee-fb3a-51c2-b4f9-0dc26cf3e2bb",
+          "_name": "Media Coverage"
+        }
+      ]
+    },
+    "Captain America": {
+      "label": "Captain America",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "64dfc6fe-1e66-5cef-b68d-2fd8e8b0d80d",
+          "_name": "Captain America"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3cc75853-1827-55d9-9c96-260ae95ac2b0",
+          "_name": "Agent 13"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "85658f54-478b-577e-8eba-e25cd3531984",
+          "_name": "Fearless Determination"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7707497c-673b-5411-9de4-fac201ecdc81",
+          "_name": "Heroic Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "16268526-efb7-5bff-b8ce-a6ecbb7480e7",
+          "_name": "Shield Block"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "99465d39-49db-5e5f-a9b9-e7ab09e79a94",
+          "_name": "Shield Toss"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9e062697-d562-564a-8020-522b57dc747a",
+          "_name": "Steve's Apartment"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3577ce90-7d68-52fe-b59b-45099335e8bd",
+          "_name": "Captain America's Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8093cd81-0ec6-5244-bfc0-915b9a4d57f9",
+          "_name": "Captain America's Shield"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "57f87f14-530d-5477-9270-a3a69b2de679",
+          "_name": "Super-Soldier Serum"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3924a9bc-008a-5807-9388-59086ab0a255",
+          "_name": "Falcon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "78a441a9-d7e9-57ad-9377-3e6e7278b4d3",
+          "_name": "Hawkeye"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "40fc4108-35fb-50fb-a4d7-92bf55e56751",
+          "_name": "Squirrel Girl"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "86f3194a-d779-5f01-84ec-d78097bb8704",
+          "_name": "Wonder Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ed665253-29e4-5466-bb4f-8b982c8442c8",
+          "_name": "Avengers Assemble!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ced1d16c-ccfd-59e3-9547-911ff77521a7",
+          "_name": "Make the Call"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c25f7b7d-848c-5701-a357-e6841c6ec289",
+          "_name": "Strength in Numbers"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "04fe3e79-279a-5d4b-93f4-bf6fa562e825",
+          "_name": "The Power of Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "dfbe6215-1c9d-5774-ab38-f807e22cb770",
+          "_name": "Quinjet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cd946d2e-d14d-5aca-beb5-b0b675c2bb48",
+          "_name": "Avengers Tower"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "4eb3440e-7d2f-5e93-8914-7bb8dddf10ef",
+          "_name": "Honorary Avenger"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "64a104f3-9bef-5186-a600-c3b7ca98937c",
+          "_name": "Man Out of Time"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "e72a7871-8f2b-5624-97a7-940d1f57a705",
+          "_name": "Hit Squad"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f6658570-036f-5d10-a68a-dd79d30bd972",
+          "_name": "Baron Zemo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Captain America Nemesis": {
+      "label": "Captain America Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "e72a7871-8f2b-5624-97a7-940d1f57a705",
+          "_name": "Hit Squad"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f6658570-036f-5d10-a68a-dd79d30bd972",
+          "_name": "Baron Zemo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Hawkeye": {
+      "label": "Hawkeye",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "61d3383d-a947-5eec-9ef9-7605d15605e4",
+          "_name": "Hawkeye"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0a84d4e8-bb71-511f-b64f-c59490f9fa6e",
+          "_name": "Hawkeye's Bow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6ca037e0-d0b1-52c6-940b-d0e9a3c7b0aa",
+          "_name": "Hawkeye's Quiver"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a471dd35-a7cc-5184-95b9-60aa847c3230",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5a0741a3-6860-50f3-a02b-d451814bc51c",
+          "_name": "Sonic Arrow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ee1fedde-83f1-5098-8afd-fbeded7a7d93",
+          "_name": "Explosive Arrow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5c1c4bff-70d2-5a51-8d3a-8bf97e5c92ed",
+          "_name": "Electric Arrow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "aefc9f0b-5a4d-5589-9e51-27948e0af2cc",
+          "_name": "Cable Arrow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "43a79a77-f3a5-5462-a661-0fa17d9baaae",
+          "_name": "Vibranium Arrow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ff5b44e3-5f86-5942-a9ee-68b7a78093d9",
+          "_name": "Expert Marksman"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b56f85bc-25b4-5216-b1ed-af7c8bd5917c",
+          "_name": "Hawkeye"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "97b98576-3317-59de-bf7b-f93adc3cefc1",
+          "_name": "Black Knight"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f75bc378-cf92-59db-bec8-daa12cd04ce2",
+          "_name": "Goliath"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b3e5830b-0771-5c46-b94c-22641faefcf4",
+          "_name": "U.S. Agent"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "80e268d0-0f82-5568-aab1-3236da7e0f91",
+          "_name": "Sky Cycle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "dd1e2956-9589-57ff-a1b2-a9e34e06f479",
+          "_name": "Team Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b276c31a-105d-5671-85e0-7c7d965bcf9d",
+          "_name": "Ready for Action"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2da8638a-9879-5094-8d84-66e6b7692dd7",
+          "_name": "Lead from the Front"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "04fe3e79-279a-5d4b-93f4-bf6fa562e825",
+          "_name": "The Power of Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "71275243-50f2-5d97-8c4e-fffac0691d2c",
+          "_name": "War Machine"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cd946d2e-d14d-5aca-beb5-b0b675c2bb48",
+          "_name": "Avengers Tower"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b9a63153-d965-536f-b703-87f359579b1e",
+          "_name": "Earth's Mightiest Heroes"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ceb9280c-e21f-52fb-8a0e-bdf377dcee42",
+          "_name": "Criminal Past"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7a03c821-53c2-5316-a47d-f7b1cd5044fe",
+          "_name": "Crossfire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9aeb2ff2-8647-50fc-97fe-f32995113113",
+          "_name": "Marked for Death"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d5137796-10b5-5795-9bfd-07000ae86d8b",
+          "_name": "Crossfire's Rifle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "76fcf525-83f8-57ed-b151-1bdb60f07b10",
+          "_name": "Sniper Shot"
+        }
+      ]
+    },
+    "Hawkeye Nemesis": {
+      "label": "Hawkeye Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7a03c821-53c2-5316-a47d-f7b1cd5044fe",
+          "_name": "Crossfire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9aeb2ff2-8647-50fc-97fe-f32995113113",
+          "_name": "Marked for Death"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d5137796-10b5-5795-9bfd-07000ae86d8b",
+          "_name": "Crossfire's Rifle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "76fcf525-83f8-57ed-b151-1bdb60f07b10",
+          "_name": "Sniper Shot"
+        }
+      ]
+    },
+    "Spider-Woman": {
+      "label": "Spider-Woman",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "dcf73118-f38c-5b27-84c6-605700ca8094",
+          "_name": "Spider-Woman"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "76067a8d-ec4d-57ca-a6c6-2bf2182d841f",
+          "_name": "Captain Marvel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4bd2ea1e-9c70-5257-8732-4dd098c41e40",
+          "_name": "Finesse"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6e173212-6f3a-562a-83c4-d2c287e0d8bc",
+          "_name": "Jessica Drew's Apartment"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a086c8f8-96ea-5345-b507-5dd049c30580",
+          "_name": "Venom Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8cd7783d-8f76-5612-ba2c-62fe71f584ff",
+          "_name": "Pheromones"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c2b4d5a1-5abb-5383-894d-f6833e98e94c",
+          "_name": "Contaminant Immunity"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9fec46f8-500c-5048-b68d-1a41eaad108a",
+          "_name": "Inconspicuous"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "1a1feeee-f252-5a31-a2ff-c58a532495e9",
+          "_name": "Self-Propelled Glide"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "84c678f6-984d-512e-a175-e3091b7496a2",
+          "_name": "Spider-Girl"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3c8506e5-d29c-5c9c-81b8-ee0f47e91ea0",
+          "_name": "Combat Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8e5f35a0-59e2-56de-ba10-903315e2615b",
+          "_name": "Tac Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ba73e3fc-f880-5401-9fc2-2b26f9c1c523",
+          "_name": "Press the Advantage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "21c21fbb-2da1-58a3-921e-bc0962f806b3",
+          "_name": "Piercing Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "85579e7e-30ed-5202-86ff-5862f8ebd737",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5d841847-94a8-5ff4-968a-fdbe5d4af9cd",
+          "_name": "Heroic Intuition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "88306c9a-ddf4-586c-85ba-ce5f3f73e78a",
+          "_name": "Skilled Investigator"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ec687afd-f821-5770-b1e8-97301d70a258",
+          "_name": "Interrogation Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6f6b93a4-36c9-5c62-9461-e2239123dbf0",
+          "_name": "Clear the Area"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "da567bf6-55c5-5630-962b-b5e33c8a0249",
+          "_name": "Uncertain Loyalties"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8cb8d93c-4abd-5ce8-b2f1-27bf7e66e834",
+          "_name": "The Viper"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "467ecf5e-aed1-520c-8bf6-66c5998d7b3f",
+          "_name": "The Viper's Ambition"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Spider-Woman Nemesis": {
+      "label": "Spider-Woman Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8cb8d93c-4abd-5ce8-b2f1-27bf7e66e834",
+          "_name": "The Viper"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "467ecf5e-aed1-520c-8bf6-66c5998d7b3f",
+          "_name": "The Viper's Ambition"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Crossbones": {
+      "label": "Crossbones",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3d3b8346-5e56-508d-95cc-2df86fe055c5",
+          "_name": "Crossbones"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "efd7b5c0-89cb-59a5-a555-9feb7f6802db",
+          "_name": "Crossbones"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "adf4e02a-e687-5859-8a4e-b587e7571dac",
+          "_name": "Crossbones"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "177f2082-ec29-5925-ae77-2c006485f70c",
+          "_name": "Attack on Mount Athena"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "83df5d46-e2a1-5dc8-aab7-d0ccd21d83c9",
+          "_name": "The Infinity Stone"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "9dfb1acb-501b-574f-b2f2-22756780d4ea",
+          "_name": "The Getaway"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fe1e73a2-b909-553d-9444-81ece938fa04",
+          "_name": "Crossbones' Machine Gun"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0368a58c-e181-5185-ad04-dc55d3d298a9",
+          "_name": "Crossbones' Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b50d78d6-b5a2-5d5c-bfe8-514808c3a29e",
+          "_name": "Hydra Bomber"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "848eed02-54fe-5467-9533-926b63e2902d",
+          "_name": "Full Auto"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8dd56f19-6dd5-500a-88cb-1c1b5f59b5c6",
+          "_name": "Hard as Nails"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1c67076f-a856-51b4-9f2e-07f10680717a",
+          "_name": "Raid the Armory"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "bdb4df44-b07f-535f-8aa5-75f8c066463c",
+          "_name": "Crossbones' Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f7582f65-3d5e-5c31-bfa1-91b775e748fc",
+          "_name": "Cornered Staff"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Crossbones"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Crossbones"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "COND",
+          "$GAME.loadRequired",
+          [
+            [
+              "LOG",
+              "Setup: Reveal top card of the experimental Weapons Deck"
+            ],
+            [
+              "SHUFFLE_GROUP",
+              "sharedEncounter3Deck"
+            ],
+            [
+              "MOVE_CARD",
+              "$GAME.groupById.sharedEncounter3Deck.parentCardIds.[0]",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Reveal \"Crossbones' Machine Gun\""
+            ],
+            [
+              "DEFINE",
+              "$ATTACHMENT_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "fe1e73a2-b909-553d-9444-81ece938fa04"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$ATTACHMENT_CARD.id",
+              "sharedVillain",
+              -1
+            ],
+            [
+              "SET",
+              "/cardById/$ATTACHMENT_CARD.id/tokens/generic",
+              [
+                "MULTIPLY",
+                2,
+                "$GAME.numPlayers"
+              ]
+            ]
+          ]
+        ]
+      ]
+    },
+    "Experimental Weapons": {
+      "label": "Experimental Weapons",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "318c8d5f-7577-55a8-98ba-e31f9069c9f5",
+          "_name": "Laser Rifle"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "54e8f1a4-f4ff-5694-9304-15ad7cbe30be",
+          "_name": "Energy Shield"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "095c40d0-c564-5174-9faf-9e07b6f20e93",
+          "_name": "Power Gauntlets"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9554f736-800f-5146-a128-ae3e4f9b1864",
+          "_name": "Exo-Suit"
+        }
+      ]
+    },
+    "Absorbing Man": {
+      "label": "Absorbing Man",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "4eadde04-59fa-53a1-affc-820382b4e468",
+          "_name": "Absorbing Man"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d30b5a21-d204-51d7-8e7c-644b16ddc60d",
+          "_name": "Absorbing Man"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d4d399ed-ae1a-540e-bd34-8a794b2d435c",
+          "_name": "Absorbing Man"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "77d43fe6-078a-5902-8a2a-21b293cc4e7e",
+          "_name": "None Shall Pass"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dbe7279f-79cc-56fa-adc2-0f737a22ff61",
+          "_name": "Dense Forest"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dfdf1e97-6cd2-5ffd-9186-a479245c92b2",
+          "_name": "Snowy Hillside"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5b6952f7-bebb-5870-b62b-6bce696413b1",
+          "_name": "Rocky Outcrop"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2ac3a7b2-467e-5af1-a924-ae3f5d84ce9b",
+          "_name": "Abandoned Facility"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d972925c-c803-58ed-9f32-2d8e048c83f2",
+          "_name": "Ball and Chain"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b4e59094-e313-561a-a14b-12fc9885693a",
+          "_name": "Stall Tactics"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c9ab1f6a-962e-5842-973c-3d7fdec14baa",
+          "_name": "Swinging Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4e44209b-b5ea-5768-9ff9-ec9183f3b519",
+          "_name": "Steel Kick"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "89b6fa91-aef8-5652-bf13-e2ecdc5b35a8",
+          "_name": "Piercing Thorns"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "70e2adca-2f41-52d9-be0d-15d7095edb07",
+          "_name": "Omni-Morph Duplication"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a1ebc3e5-d1b1-5f7d-9ade-2b8f8bc31167",
+          "_name": "Icy Grip"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fb8d596e-87f0-58e8-8bad-40f1d1469f49",
+          "_name": "Avalanche!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fa891b35-2416-5449-862d-ab55681dd786",
+          "_name": "Super Absorbing Power"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Absorbing Man"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Discard cards until environment is discarded"
+        ],
+        [
+          "DISCARD_UNTIL",
+          "sharedEncounterDeck",
+          "sharedVillain",
+          [
+            "POINTER",
+            [
+              "EQUAL",
+              "$CARD_ITEM.sides.A.type",
+              "Environment"
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Reveal Super Absorbing Power"
+            ],
+            [
+              "VAR",
+              "$ENV_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "fa891b35-2416-5449-862d-ab55681dd786"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$ENV_CARD.id",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ]
+      ]
+    },
+    "Taskmaster": {
+      "label": "Taskmaster",
+      "cards": [
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "3542181f-2fa7-5949-b2b5-28526ec18659",
+          "_name": "Elektra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5d47c784-334f-5ca7-bc93-cea2f5d757f0",
+          "_name": "Hydra Hunter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d5abf1c7-3fdb-55c9-9f76-e802da7449f0",
+          "_name": "Taskmaster's Sword"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "63c4a82c-d8a5-5eb5-bb06-120c5b693d89",
+          "_name": "Taskmaster's Shield"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "db9c35f7-bbbc-5c90-a42f-6e887f73009f",
+          "_name": "Photographic Reflexes"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0fe5d24b-fedc-57db-a3fb-fdea7e85946a",
+          "_name": "Mimicry"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a4b46a4e-9c52-51dd-9230-5fecbd77b5f9",
+          "_name": "Hunted by Hydra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "00ecbfb9-a9bd-537a-9d4d-3fcb320c7665",
+          "_name": "Captured by Hydra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "92e67a3a-ec2c-5ff4-afda-524801fe6623",
+          "_name": "Taskmaster's Training Camp"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "767de76a-f2f2-5576-b4fe-651a408a629b",
+          "_name": "Taskmaster"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "370b0158-be75-5e8b-b699-dee072cffa05",
+          "_name": "Taskmaster"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "dc77f359-d36b-5756-b655-d0a7e7762a09",
+          "_name": "Taskmaster"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "7ba2bc90-2346-5444-8fc7-b3163f3b7098",
+          "_name": "Hunting Down Heroes"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "395a9962-ccc8-5316-a7d3-17943ea43a15",
+          "_name": "Moon Knight"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "9b0a9e12-ce1c-5e79-8662-39d0b0350dac",
+          "_name": "Shang-Chi"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "22b0ed48-1e10-50af-b44f-f2a65065c976",
+          "_name": "White Tiger"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Taskmaster"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Taskmaster"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "COND",
+          "$GAME.loadRequired",
+          [
+            [
+              "LOG",
+              "Setup: Put \"Hydra Patrol\" into play"
+            ],
+            [
+              "DEFINE",
+              "$CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "8b80afb9-e793-5d19-9d96-4a181c220723"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Deal each player an encounter card"
+            ],
+            [
+              "FOR_EACH_VAL",
+              "$PLAYER_N",
+              "$PLAYER_ORDER",
+              [
+                "ACTION_LIST",
+                "dealEncounterFacedown"
+              ]
+            ]
+          ]
+        ]
+      ]
+    },
+    "Zola": {
+      "label": "Zola",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "91a325e0-fa8e-55e9-80c5-3fcdca738499",
+          "_name": "Zola"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "2a9466f9-dc4a-5b13-ac7d-cfb919503ebd",
+          "_name": "Zola"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "0a5af431-4fdf-55c3-b4a8-e0f440069e02",
+          "_name": "Zola"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "7f5667fd-8c5b-521a-b849-b34c6d021e17",
+          "_name": "The Island of Dr. Zola"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "588ae18f-891b-56e2-a4a1-1631cb99beb5",
+          "_name": "The Mad Doctor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "28ffca31-8ff0-5538-807c-7354e3ce890a",
+          "_name": "Ultimate Bio-Servant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "a9ebe73c-2dc5-5f3a-8a8a-ec66a458aa52",
+          "_name": "Zola's Mutate"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "ca16457f-07e5-5430-91bf-b67a59ba4ed9",
+          "_name": "Berserk Mutate"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "1ef69b26-54af-5364-bbc0-011ffe6eb812",
+          "_name": "Defensive Programming"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "63f9351e-8092-5adb-85ac-92d69a47c641",
+          "_name": "Pain Inhibitors"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b9c0216d-ab9d-5298-b477-4804d1ec311e",
+          "_name": "Neurological Implants"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "8395df3b-624d-5323-8247-9707767e2705",
+          "_name": "Mind Ray"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b00ede63-f751-56c9-a27b-9f1402763b10",
+          "_name": "Technological Enhancements"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "31df8878-df81-50b3-a7c3-d18955a6b2ca",
+          "_name": "Hydra Prison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7017de0e-2e3c-597d-8439-9211640c8c0f",
+          "_name": "Test Subjects"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9e9620a7-5bc2-59d2-82e6-0891ae9084eb",
+          "_name": "Zola's Experiments"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Zola"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Reveal \"Hydra Prison\""
+        ],
+        [
+          "DEFINE",
+          "$CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "31df8878-df81-50b3-a7c3-d18955a6b2ca"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "LOG",
+          "Setup: Every play puts \"Ultimate Bio-Servant\" into play engaged"
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$PLAYER_N",
+          "$PLAYER_ORDER",
+          [
+            [
+              "DEFINE",
+              "$CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "AND",
+                  [
+                    "EQUAL",
+                    "$CARD.databaseId",
+                    "28ffca31-8ff0-5538-807c-7354e3ce890a"
+                  ],
+                  [
+                    "EQUAL",
+                    "$CARD.groupId",
+                    "sharedEncounterDeck"
+                  ]
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "{{$PLAYER_N}}Engaged",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Reveal \"Test Subjects\""
+            ],
+            [
+              "DEFINE",
+              "$CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "7017de0e-2e3c-597d-8439-9211640c8c0f"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ]
+      ]
+    },
+    "Red Skull": {
+      "label": "Red Skull",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "23ce36b2-826a-54e0-b077-ffe7c18ddeec",
+          "_name": "Red Skull"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "5fb15155-d81f-52d0-8b32-33a9659ccfdb",
+          "_name": "Red Skull"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "02412fa3-3d8b-5026-95db-5c3ef3c947d0",
+          "_name": "Red Skull"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "3fe59968-4508-5465-9844-5c41d5800ae2",
+          "_name": "The Rise of Red Skull"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "5f9298ea-4b19-5c28-9b44-8c7cefa83a9d",
+          "_name": "New World Hydra"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "afc9a3b4-e174-5581-9db7-ab036366bc4a",
+          "_name": "The Sleeper"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "ca4b32f8-8773-5eff-976e-dff774f8717e",
+          "_name": "Hydra Exo-Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9ea8d97f-02da-5b5f-9eb6-5bc42faeb76e",
+          "_name": "Red Skull's Luger"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7807587c-4a7c-5da8-81d8-7fce385dd2e3",
+          "_name": "Red Skull's Right Hook"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "42b47a0b-269d-5666-b93e-641d5e0ac3b6",
+          "_name": "Master Strategist"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9c3caf05-5e1d-5c42-9dc3-3c36a318e077",
+          "_name": "Twisted Reality"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b954b1b9-b664-53a6-9806-2382a9992ec5",
+          "_name": "Bitter Rival"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5607a468-82c3-5c88-ba90-23ee9e6c4282",
+          "_name": "Spreading Lies"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "dceb9f27-ee5c-54f4-9173-31c37334ba2d",
+          "_name": "Infinite Power"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f633ae50-1a6f-5225-86fc-f54af3ffbdab",
+          "_name": "The Red House"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9d2f20b5-cc36-5afb-8255-8f20730a7515",
+          "_name": "The Sleeper Awakened"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "10b08e7f-91c2-5a9b-abcf-3bac1cc499d6",
+          "_name": "Prison Camps"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1753eb61-d3e4-5a5e-8158-4fc2c9bc3c41",
+          "_name": "Censor the Past"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0d38d320-b0f2-582d-9667-a2007eb078d4",
+          "_name": "Hydra Reinforcements"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eaeec600-9eaa-51ca-80be-929447dfb736",
+          "_name": "Mass Chaos"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Red Skull"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Create Side-Scheme deck"
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$CARD",
+          "$GAME.groupById.sharedEncounterDeck.parentCards",
+          [
+            "COND",
+            [
+              "EQUAL",
+              "$CARD.sides.A.type",
+              "Side Scheme"
+            ],
+            [
+              "MOVE_CARD",
+              "$CARD.id",
+              "sharedEncounter2Deck",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Deal each player an encounter card"
+            ],
+            [
+              "FOR_EACH_VAL",
+              "$PLAYER_N",
+              "$PLAYER_ORDER",
+              [
+                "ACTION_LIST",
+                "dealEncounterFacedown"
+              ]
+            ]
+          ]
+        ]
+      ]
+    },
+    "Hydra Assault": {
+      "label": "Hydra Assault",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "a0b55d92-d818-5e48-ac2d-9fc58b02f79d",
+          "_name": "Hydra Flame-Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2dd3a5a7-3549-546e-b09d-1f596c93e10e",
+          "_name": "Hydra Jet-Trooper"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Weapon Master": {
+      "label": "Weapon Master",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fecf8e5e-b9bf-571a-807d-5b02f7eca9cb",
+          "_name": "Combat Knife"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7c9e0604-3ca2-51cc-aa95-50cb84e90797",
+          "_name": "Hydra Sidearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d94f00fc-03d9-536f-a2cf-c2e925b01228",
+          "_name": "Weapon Master"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "78391cb4-22b0-5c80-a7cc-6c135c2ba917",
+          "_name": "Concussion Grenade"
+        }
+      ]
+    },
+    "Hydra Patrol": {
+      "label": "Hydra Patrol",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8b80afb9-e793-5d19-9d96-4a181c220723",
+          "_name": "Hydra Patrol"
+        }
+      ]
+    },
+    "Hydra Campaign": {
+      "label": "Hydra Campaign",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "0669d720-359d-5a5a-9f87-673ff1f217a0",
+          "_name": "Adrenal Stims"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "ffb40004-c17e-5bdd-a5ef-1dc10a30c971",
+          "_name": "Tactical Scanner"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c278320b-4166-54c9-9a1f-073f8050777a",
+          "_name": "Emergency Teleporter"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "03c45e94-50e9-5bfc-a1f6-431f5a585fb3",
+          "_name": "Laser Cannon"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "da0868cb-a279-501d-b7f3-f4fecc7efa53",
+          "_name": "Basic Thwart Upgrade"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "37fe1bb0-f140-5fa0-985e-6edbf1beb122",
+          "_name": "Basic Attack Upgrade"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "839595f4-66f1-51e3-8d52-1b549cae936b",
+          "_name": "Basic Defense Upgrade"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "8bbd841c-2637-59e5-afe6-57d5c4da78ac",
+          "_name": "Basic Recovery Upgrade"
+        }
+      ]
+    },
+    "Expert Campaign": {
+      "label": "Expert Campaign",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1fa62357-d66b-5aba-90f7-f38e0683c141",
+          "_name": "Zola's Algorithm"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b884c0b1-4a54-5c71-8208-06b61e7c69ad",
+          "_name": "Medical Emergency"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c106d37f-70e6-5e2d-b4f6-59dcd3d24ca1",
+          "_name": "Martial Law"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "87e7c911-61c0-5ec3-a2e1-f286c0d46bd6",
+          "_name": "Anti-Hero Propaganda"
+        }
+      ]
+    },
+    "Ms. Marvel": {
+      "label": "Ms. Marvel",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "0141f01b-b517-5d41-84ee-539c58278adb",
+          "_name": "Ms. Marvel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0ebb8d7e-7bf6-56f1-8de0-34f2ebec1a3e",
+          "_name": "Red Dagger"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "db2f38ef-f456-52a7-8221-33eb1da03178",
+          "_name": "Big Hands"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5d521ffb-0ee2-5f7c-bfb9-fd20bdf2db53",
+          "_name": "Sneak By"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4b478061-be05-54be-80e5-3fb9bff8535e",
+          "_name": "Wiggle Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8ad11dda-d287-5b02-b10d-ec9689d55209",
+          "_name": "Aamir Khan"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "214fc769-d1f8-5aa2-8820-1cf47215c3de",
+          "_name": "Bruno Carrelli"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c02a2072-893f-58e1-bc38-11f2f1657bd9",
+          "_name": "Nakia Bahadir"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ed68faaa-b38a-5bc9-b4ed-a7547c2ed430",
+          "_name": "Biokinetic Polymer Suit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c71a5202-a9b2-550c-8dfa-ca3197fa9673",
+          "_name": "Embiggen!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d79da75d-aab5-5370-b947-968855a0b40a",
+          "_name": "Shrink"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f3eeb9b1-82ea-5eeb-a346-7a6d6ac89f1c",
+          "_name": "Nova"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a793780e-eb17-530b-8723-c7c295f0fe3e",
+          "_name": "Get Behind Me!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b78dfdd3-106f-558f-a6a9-38509e8193fe",
+          "_name": "Preemptive Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "0dd60cc0-37ba-5f3a-bad9-5b9c53126ca2",
+          "_name": "Tackle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4f8dd69d-4555-5af5-b48f-709a73d6acea",
+          "_name": "The Power of Protection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6829d654-2257-5e52-8e4d-14a14a3d3a70",
+          "_name": "Energy Barrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9ed693ae-5c58-5190-8c8e-aeadf3304f7f",
+          "_name": "Lockjaw"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9dea3718-60f9-5b5f-9a49-f692f21e819c",
+          "_name": "Endurance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "18d10de0-11c4-5842-925d-bdb66455b215",
+          "_name": "Enhanced Reflexes"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b2ad396f-8b81-5cba-a034-d71be9924e21",
+          "_name": "Home by Dawn"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "16f3ed1b-8509-52b3-a0d8-50e55a59c5fd",
+          "_name": "Generation Why?"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2018c44d-9dc9-532d-8295-e9ddb4946ce1",
+          "_name": "Thomas Edison"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2294b2e6-27cc-5611-9f96-ee1df53aaf00",
+          "_name": "Edison's Giant Robot"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "53fe1558-ab2e-5fae-9179-f98ac59963d6",
+          "_name": "Harvest"
+        }
+      ]
+    },
+    "Ms. Marvel Nemesis": {
+      "label": "Ms. Marvel Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "16f3ed1b-8509-52b3-a0d8-50e55a59c5fd",
+          "_name": "Generation Why?"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2018c44d-9dc9-532d-8295-e9ddb4946ce1",
+          "_name": "Thomas Edison"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2294b2e6-27cc-5611-9f96-ee1df53aaf00",
+          "_name": "Edison's Giant Robot"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "53fe1558-ab2e-5fae-9179-f98ac59963d6",
+          "_name": "Harvest"
+        }
+      ]
+    },
+    "Thor": {
+      "label": "Thor",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "44040275-d79f-5d04-8991-439422b73d60",
+          "_name": "Thor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0693c988-9731-566a-8fb2-7056ba47cb87",
+          "_name": "Lady Sif"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "863b3a05-15b8-569c-b94b-c6195472572a",
+          "_name": "Defender of the Nine Realms"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2a0b8fb2-bdca-5fbb-b5ab-8acf73384145",
+          "_name": "For Asgard!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d72823e3-2c7c-5337-bcfb-f6d2b4f6bbb0",
+          "_name": "Hammer Throw"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "01b1c6cb-7ac8-5ac0-9d63-ca9b8eea04f8",
+          "_name": "Lightning Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7477e302-14a5-531a-beb7-54d22a50270c",
+          "_name": "Asgard"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8ff6776e-8919-5623-9c3d-f42fb102678d",
+          "_name": "God of Thunder"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8ba411b2-7245-56fa-843b-38e3281a4e2f",
+          "_name": "Mjolnir"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "13a14d7d-e386-5538-ab66-04962af70dde",
+          "_name": "Thor's Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e483bdf1-af99-5135-8544-53916c10230e",
+          "_name": "Hercules"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "caa8bd83-cf69-50c3-ab74-e80bf1b8b79d",
+          "_name": "Valkyrie"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b7b48c3f-99e2-5e32-82b5-3f6f7b955781",
+          "_name": "Chase Them Down"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "96dfd02b-fa24-56a1-aa2d-6d35e9438552",
+          "_name": "Get Over Here!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e7c6dc4e-ab8d-5f53-9046-3f259bb89d4b",
+          "_name": "Mean Swing"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2d2e09aa-0d98-5cfa-94b9-c06e6bf854aa",
+          "_name": "Hall of Heroes"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a60533b4-33b1-5ccf-aabd-bfb00902f0ec",
+          "_name": "Battle Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "88358c9f-aff9-5a05-8c99-8618eeae0bcc",
+          "_name": "Jarnbjorn"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6d8c2a6f-d5d3-5702-8baa-616e20fb7d2f",
+          "_name": "Heimdall"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f7e748fa-2127-54b3-82ee-409075115112",
+          "_name": "Invulnerability"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "05fc5d0d-4b79-5d29-9d58-0a47e5ecb563",
+          "_name": "Odin's Anger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4a5a56c4-1b0a-5c38-a49d-8219935d9194",
+          "_name": "Family Feud"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "fd9cf4b5-6421-5640-8da5-83bda653fdc7",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "a8acb875-5a8b-560e-9bb8-5b34f93ce397",
+          "_name": "Frost Giant"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13a27c61-46ae-53cc-8a96-fe8a1f6af294",
+          "_name": "Trickster"
+        }
+      ]
+    },
+    "Thor Nemesis": {
+      "label": "Thor Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4a5a56c4-1b0a-5c38-a49d-8219935d9194",
+          "_name": "Family Feud"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "fd9cf4b5-6421-5640-8da5-83bda653fdc7",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "a8acb875-5a8b-560e-9bb8-5b34f93ce397",
+          "_name": "Frost Giant"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13a27c61-46ae-53cc-8a96-fe8a1f6af294",
+          "_name": "Trickster"
+        }
+      ]
+    },
+    "Wrecking Crew": {
+      "label": "Wrecking Crew",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e2afe3d-b414-5b81-a6c6-85f8c6b3e77a",
+          "_name": "Top Talent"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "45b94dfd-0b66-57e1-9a6d-76615e6140a0",
+          "_name": "Wrecker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b45b125f-54b3-5fb7-9367-d75599da66cd",
+          "_name": "Bulldozer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f68f343a-4a3d-5580-89bf-906527e5b233",
+          "_name": "Piledriver"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c52a222d-540a-59a0-8b37-bd6ee6f026f4",
+          "_name": "Thunderball"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f1e6a406-b11d-549b-a8f2-a30d716a0e2d",
+          "_name": "Combined Effort"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "562519c3-03f7-55da-86a1-0e52ca1cf2c7",
+          "_name": "Magic Muscles"
+        }
+      ]
+    },
+    "Wrecker": {
+      "label": "Wrecker",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "489a8b70-2fda-520e-a169-21f5511dca3d",
+          "_name": "Wrecker"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "48cb092f-c4e9-5d89-982d-73b3fde2c02d",
+          "_name": "Wrecker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f41470b2-4443-58b5-a0ad-75d611c3763f",
+          "_name": "Day of Reckoning"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41171e14-65db-54ef-a00d-bf0b5dad91c8",
+          "_name": "Held Hostage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e42997c6-017e-5219-97d3-3ada673f78a1",
+          "_name": "Magic Crowbar"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4024f08a-57b4-5106-a594-125b2be17ef6",
+          "_name": "Wrecker's Command"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a197d60b-917d-56db-b885-bad6656d3d5b",
+          "_name": "Corrupt Prison Guard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "960336a5-9b7a-5123-a72b-b1fd7484ad2b",
+          "_name": "Escaped Convict"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dcaaf168-9df4-51ee-8a33-0efd3a6957b5",
+          "_name": "Buddy System"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4cd42c07-c482-5f6d-b3c0-2cb291204354",
+          "_name": "Chaos in the Prison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5f48c8f3-9485-54dd-8b81-e7f57c8a9928",
+          "_name": "Crowbar Toss"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0a47b40a-82d1-5a64-a36c-83af499b1d32",
+          "_name": "Get Wrecked!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b5f70751-f5bc-57c2-8834-ca941695dbbf",
+          "_name": "\"I've Been Waiting For This!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "32864eef-f364-565b-8f78-fdd568235189",
+          "_name": "Mystical Link"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3d7c03ea-82f8-5de1-8af8-b26187b74b8c",
+          "_name": "\"You're Dead Meat!\""
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Thunderball": {
+      "label": "Thunderball",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "b026b48a-523b-5f74-8098-18397ed00aff",
+          "_name": "Thunderball"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "08bd20e7-b262-5c4c-8438-aeebc4fcfe63",
+          "_name": "Thunderball"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "60b43d05-6cc6-5849-82d0-2a51f159a83b",
+          "_name": "Thunderstruck"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "441ac869-caaa-5e8a-a30f-687a217dbc40",
+          "_name": "Ball and Chain"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41171e14-65db-54ef-a00d-bf0b5dad91c8",
+          "_name": "Held Hostage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "066af6a2-76cc-566c-a814-3b76a0a5fa35",
+          "_name": "Radioactive Buildup"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a197d60b-917d-56db-b885-bad6656d3d5b",
+          "_name": "Corrupt Prison Guard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "960336a5-9b7a-5123-a72b-b1fd7484ad2b",
+          "_name": "Escaped Convict"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dcaaf168-9df4-51ee-8a33-0efd3a6957b5",
+          "_name": "Buddy System"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4cd42c07-c482-5f6d-b3c0-2cb291204354",
+          "_name": "Chaos in the Prison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "500fd171-e6b8-5623-b413-febfe573de67",
+          "_name": "Energy Projectiles"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0a47b40a-82d1-5a64-a36c-83af499b1d32",
+          "_name": "Get Wrecked!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b5f70751-f5bc-57c2-8834-ca941695dbbf",
+          "_name": "\"I've Been Waiting For This!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7e326fa8-c207-52ff-8619-27fbdb271aea",
+          "_name": "Lightning Blast"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "893b60ff-1630-5d12-b210-584ed96aaf27",
+          "_name": "Tactical Prowess"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Piledriver": {
+      "label": "Piledriver",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "127b6fa0-ab52-53e5-b325-fec0406746b7",
+          "_name": "Piledriver"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "aa1e9f9d-a1ed-5ed4-adc6-8cc99bf63a3a",
+          "_name": "Piledriver"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "16351e0a-d3b3-5faf-9446-7208ce7135e6",
+          "_name": "Pile It On!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ccf5cec8-0c2e-55fc-9b41-ead466fe4c2c",
+          "_name": "Distracting Taunts"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41171e14-65db-54ef-a00d-bf0b5dad91c8",
+          "_name": "Held Hostage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a197d60b-917d-56db-b885-bad6656d3d5b",
+          "_name": "Corrupt Prison Guard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "960336a5-9b7a-5123-a72b-b1fd7484ad2b",
+          "_name": "Escaped Convict"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dcaaf168-9df4-51ee-8a33-0efd3a6957b5",
+          "_name": "Buddy System"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0a47b40a-82d1-5a64-a36c-83af499b1d32",
+          "_name": "Get Wrecked!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b5f70751-f5bc-57c2-8834-ca941695dbbf",
+          "_name": "\"I've Been Waiting For This!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1112471b-9886-5cca-a99e-d81e0cb2361c",
+          "_name": "Oversized Hands"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "68814772-8118-5a15-ae78-8c5a84104baa",
+          "_name": "Escape Plan"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c90a8408-afeb-5018-b486-604c6b90113e",
+          "_name": "Pummel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1b5bdc27-de10-566b-91bc-ff89a729abcd",
+          "_name": "Uncanny Resilience"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Bulldozer": {
+      "label": "Bulldozer",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "94e32f67-b043-5a9c-9f4e-0aed24e0de38",
+          "_name": "Bulldozer"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "1e987078-42e0-54d3-a4fe-fc76376cdf3e",
+          "_name": "Bulldozer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "413ce050-fada-5565-91d6-f671e1dc6561",
+          "_name": "Clear the Road"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eb71c160-f487-58b7-b505-696b4bf44668",
+          "_name": "Bulldozer's Helmet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41171e14-65db-54ef-a00d-bf0b5dad91c8",
+          "_name": "Held Hostage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "51431549-266f-5e68-aaa2-d22f4b2124ed",
+          "_name": "Ramming Speed"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a197d60b-917d-56db-b885-bad6656d3d5b",
+          "_name": "Corrupt Prison Guard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "960336a5-9b7a-5123-a72b-b1fd7484ad2b",
+          "_name": "Escaped Convict"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dcaaf168-9df4-51ee-8a33-0efd3a6957b5",
+          "_name": "Buddy System"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "e3e0feeb-6078-5b32-a6db-2d706307fc5e",
+          "_name": "Bull Rush"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4cd42c07-c482-5f6d-b3c0-2cb291204354",
+          "_name": "Chaos in the Prison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0a47b40a-82d1-5a64-a36c-83af499b1d32",
+          "_name": "Get Wrecked!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "bfb40c98-747b-58a4-8e9c-dcbccaa97e56",
+          "_name": "Headbutt"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "123cff73-5101-52e2-a2e2-531d3711048e",
+          "_name": "Leading the Charge"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Black Widow": {
+      "label": "Black Widow",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "7ab76f46-aa68-5d9e-881c-eb1b0fbf791c",
+          "_name": "Black Widow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "11541a10-1f3c-59c7-b7a9-94c27c5d1639",
+          "_name": "Winter Soldier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ab496197-a332-5096-a510-dd3a163f2d95",
+          "_name": "Covert Ops"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c46698d1-ec21-5101-a12f-1e7eab6b3ba8",
+          "_name": "Dance of Death"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5d22326f-f02e-534d-ba55-1ab73880719f",
+          "_name": "Safe House #29"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b408ab01-ad36-5ea7-9293-1dc51f70a85e",
+          "_name": "Attacrobatics"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4133f563-fe26-5466-bbd5-ab2f539dad2f",
+          "_name": "Black Widow's Gauntlet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "1d751072-1120-5d81-96d7-7702a4fec025",
+          "_name": "Grappling Hook"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "04aecfaf-1fda-5451-9719-c895c2c1b5ce",
+          "_name": "Synth-Suit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "57facdd6-2059-5300-920b-1e51989f68d5",
+          "_name": "Widow's Bite"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bc7a67f8-50ed-5ca0-8004-2ed1379258d7",
+          "_name": "Agent Coulson"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "97ee5c99-64b3-53e9-a6c4-975a1040f55e",
+          "_name": "Quake"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "73c1f881-8ce6-5436-af98-7a37bc373e1b",
+          "_name": "Stealth Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "beba6d45-629f-55c9-94cf-3568c144eb6b",
+          "_name": "The Power of Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ec687afd-f821-5770-b1e8-97301d70a258",
+          "_name": "Interrogation Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "560cbe53-74a5-5338-bab9-5dbdb8cbfe02",
+          "_name": "Surveillance Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c35b8ec4-a1c3-5112-8805-cb8e83d8a6d4",
+          "_name": "Counterintelligence"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "33878f21-1098-55c1-8177-eae7f6674bb2",
+          "_name": "Spycraft"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a0165626-0a00-5343-9184-3cf44aaa8941",
+          "_name": "Nick Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c2c11795-326e-57c3-9712-0e6736d8ac03",
+          "_name": "Quincarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "255ac2da-c354-5f00-902c-943f856d316a",
+          "_name": "Target Acquired"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "037bee61-72e2-560b-9407-ecac9b499202",
+          "_name": "Burn Notice"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1cb1c397-6151-5831-a2c3-de834a035edb",
+          "_name": "Taskmaster"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c64b2b72-b430-5ef0-8233-3313570a5c01",
+          "_name": "Killer for Hire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ad69696c-7e2e-5c2d-a9bf-30d5eb4cf293",
+          "_name": "Hydra Mercenary"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "99282c78-c6a1-521f-9c28-c5dcd36ca5fb",
+          "_name": "Deadly Shot"
+        }
+      ]
+    },
+    "Black Widow Nemesis": {
+      "label": "Black Widow Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1cb1c397-6151-5831-a2c3-de834a035edb",
+          "_name": "Taskmaster"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c64b2b72-b430-5ef0-8233-3313570a5c01",
+          "_name": "Killer for Hire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ad69696c-7e2e-5c2d-a9bf-30d5eb4cf293",
+          "_name": "Hydra Mercenary"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "99282c78-c6a1-521f-9c28-c5dcd36ca5fb",
+          "_name": "Deadly Shot"
+        }
+      ]
+    },
+    "Doctor Strange": {
+      "label": "Doctor Strange",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "1a09dcb7-083f-5781-87c0-7b0d723cd232",
+          "_name": "Doctor Strange"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6db2785d-ad94-519a-891d-666aef71e3b1",
+          "_name": "Wong"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "83ed95c9-68fc-582f-abd9-0bffcbb36d1b",
+          "_name": "Astral Projection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "eed4fa8b-95c6-5ea9-abcc-8214a70bd966",
+          "_name": "Magic Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "358a6e46-ed00-5ca8-8cd5-8def16035b34",
+          "_name": "Master of the Mystic Arts"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9108e909-bd13-5195-a1c5-245819a21488",
+          "_name": "Mystical Studies"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b082f839-7afa-54db-ae98-6077346c4afe",
+          "_name": "Protective Ward"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8270b2b0-4aee-5075-af00-162455465283",
+          "_name": "Sanctum Sanctorum"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d7758cd3-d16e-5976-8344-b8bde79ed474",
+          "_name": "Cloak of Levitation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "709568a4-7506-5c8f-9fb5-3cd3830254df",
+          "_name": "Magical Enhancements"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "716a5369-f05a-51ba-9c08-95fca0b1b3d5",
+          "_name": "The Eye of Agamotto"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "17c5b5af-c634-5fae-ba7c-c544780df6f4",
+          "_name": "Brother Voodoo"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b93cee39-128f-5aee-8d62-b91fb57a67e2",
+          "_name": "Clea"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b3bae4c7-9e3c-5428-84fa-b078c68fe514",
+          "_name": "Iron Fist"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "707bd795-e84b-5d05-94c2-cf39aa316849",
+          "_name": "Desperate Defense"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5fb4f616-0e96-5fde-8565-18c082bffbba",
+          "_name": "Momentum Shift"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4f8dd69d-4555-5af5-b48f-709a73d6acea",
+          "_name": "The Power of Protection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d52cd91a-ee3d-5021-b735-d54dfe3ff9c8",
+          "_name": "Med Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "385e846a-7f7c-5b0a-8a3d-cd50d387ff9c",
+          "_name": "The Night Nurse"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7554c171-75be-5929-a456-2b19400b1771",
+          "_name": "Unflappable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "910e84a3-9f03-5bf4-be50-822182d11750",
+          "_name": "Warning"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "538319de-2d75-56c0-8546-1d02c0e2c6ab",
+          "_name": "The Sorcerer Supreme"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9d10b930-4c96-5371-94fa-0869fd9f8530",
+          "_name": "Physical Toll"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f48e490c-f9c8-5302-aa46-e3cab3c93521",
+          "_name": "Baron Mordo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2082491b-0a7d-5db2-9779-6f60204541ba",
+          "_name": "Open the Dark Dimension"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "99d3688d-4bab-562e-a254-32bd08c8c1a8",
+          "_name": "Counterspell"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7ca114b6-5b59-56ed-8ba5-438cd3b03527",
+          "_name": "Thoughtcasting"
+        }
+      ]
+    },
+    "Doctor Strange Nemesis": {
+      "label": "Doctor Strange Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f48e490c-f9c8-5302-aa46-e3cab3c93521",
+          "_name": "Baron Mordo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2082491b-0a7d-5db2-9779-6f60204541ba",
+          "_name": "Open the Dark Dimension"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "99d3688d-4bab-562e-a254-32bd08c8c1a8",
+          "_name": "Counterspell"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7ca114b6-5b59-56ed-8ba5-438cd3b03527",
+          "_name": "Thoughtcasting"
+        }
+      ]
+    },
+    "Invocation": {
+      "label": "Invocation",
+      "cards": [
+        {
+          "loadGroupId": "playerNDeck2",
+          "quantity": 1,
+          "databaseId": "1776d8ec-5fb2-5f11-b5a9-da225f97c0b5",
+          "_name": "Crimson Bands of Cyttorak"
+        },
+        {
+          "loadGroupId": "playerNDeck2",
+          "quantity": 1,
+          "databaseId": "26c0badc-c242-5e4a-a18b-35db8494dbaf",
+          "_name": "Images of Ikonn"
+        },
+        {
+          "loadGroupId": "playerNDeck2",
+          "quantity": 1,
+          "databaseId": "b4f8c727-0c70-5950-b8c6-aed623e25867",
+          "_name": "Seven Rings of Raggadorr"
+        },
+        {
+          "loadGroupId": "playerNDeck2",
+          "quantity": 1,
+          "databaseId": "a7b17bb0-61c5-5e97-8731-d577b2b77b54",
+          "_name": "Vapors of Valtorr"
+        },
+        {
+          "loadGroupId": "playerNDeck2",
+          "quantity": 1,
+          "databaseId": "16305851-97eb-5b07-89c9-9bbe122e8344",
+          "_name": "Winds of Watoomb"
+        }
+      ]
+    },
+    "Hulk": {
+      "label": "Hulk",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "a9d504c5-d70f-59cf-8263-257a5e49297c",
+          "_name": "Hulk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9eaf8b2f-6adb-50b5-a5fd-046e9ef94f5f",
+          "_name": "Crushing Blow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "88315a81-4164-5c19-8d4c-adc0977556f0",
+          "_name": "Hulk Smash"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "0a4ebfbe-e580-5498-a9c3-bdea75a8163c",
+          "_name": "Sub-Orbital Leap"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9e119f34-6781-5ed1-b60f-11efbb84734f",
+          "_name": "Thunderclap"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2466a0ab-a970-53b5-b87c-e19d53496205",
+          "_name": "Unstoppable Force"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "f74a9608-28f5-5f39-928b-c70c88f7ff85",
+          "_name": "Limitless Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7b16b969-23df-5d61-9af4-6ff60b0afe84",
+          "_name": "Banner's Laboratory"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9b4580e2-f7c7-584d-b88c-80c39ee93178",
+          "_name": "Boundless Rage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "fc16adeb-cb34-5ffe-a20c-e3150edeba55",
+          "_name": "Immovable Object"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d6167ddb-1d11-5a94-9420-06f4365fcf88",
+          "_name": "Brawn"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5555b8d8-48ce-5312-96b6-e93e03001878",
+          "_name": "Sentry"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c48cfaec-8cd8-528d-9a01-b341ab4ff32d",
+          "_name": "She-Hulk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a3779865-d114-52e8-b94a-a84081e990a2",
+          "_name": "Drop Kick"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e7f91095-33c3-58d9-bf52-dcb080f587dd",
+          "_name": "Toe to Toe"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "55b6ed17-0589-5a83-872f-0364cf0aac6a",
+          "_name": "\"You'll Pay for That!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b10fb8f5-7149-5844-8b81-67e49da9361f",
+          "_name": "Martial Prowess"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5fe4c598-2cb8-5dc5-a351-8d221a67ff31",
+          "_name": "To the Rescue!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2b7a5899-9fc2-5dad-a37e-242b6d2ef1a5",
+          "_name": "Inner Demons"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ae31d512-9c24-5afc-9bb8-f13da4740f68",
+          "_name": "Abomination"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "40d4e6e4-5ecc-5e42-8bf1-10691e43e580",
+          "_name": "Total Destruction"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "e296822a-afc0-58e1-b69b-1a5843d12300",
+          "_name": "Clash of the Titans"
+        }
+      ]
+    },
+    "Hulk Nemesis": {
+      "label": "Hulk Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ae31d512-9c24-5afc-9bb8-f13da4740f68",
+          "_name": "Abomination"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "40d4e6e4-5ecc-5e42-8bf1-10691e43e580",
+          "_name": "Total Destruction"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "e296822a-afc0-58e1-b69b-1a5843d12300",
+          "_name": "Clash of the Titans"
+        }
+      ]
+    },
+    "Kang": {
+      "label": "Kang",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "2531c227-fb70-588e-92a4-e242e60f41e7",
+          "_name": "Kang (The Conqueror)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3ec35abb-ad36-5a9a-88b7-33436c3478fc",
+          "_name": "Kang (Immortus)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "922092fa-fcdd-50ee-8a4f-37bc68843ee6",
+          "_name": "Kang (Iron Lad)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "20d73026-d831-5b50-8d3b-2d2be4bdf0ab",
+          "_name": "Kang (Rama-Tut)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "8da7c346-63f0-590c-8960-92bd0337787f",
+          "_name": "Kang (Scarlet Centurion)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "ebb16bce-3d0e-5a08-a320-14695f3de32f",
+          "_name": "Kang (The Conqueror)"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "63cd1790-ab5b-5f24-809e-8a84ad853fe0",
+          "_name": "Inexorable Fate"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "f209d4d8-d42d-52bf-85eb-b81734b4a495",
+          "_name": "The Realm of Rama-Tut"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "8e779d6e-c96a-599b-abeb-5e403c87094a",
+          "_name": "The Present Future War"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "aefc1562-4e6d-55c1-8f52-89d28e962d15",
+          "_name": "Kang's Wrath"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8302eb5a-d833-59e9-b0e9-5521f6f6c298",
+          "_name": "Temporal Shield"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "df949c39-e322-5b7d-872c-e64294b28515",
+          "_name": "Future Weapon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "47cf0fb7-6013-59af-ac62-3103b2d7a906",
+          "_name": "Frozen in Time"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "da130206-7971-54c1-adb8-8637e8a796ce",
+          "_name": "Macrobots"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2167f969-9e2a-5374-8107-504de363175f",
+          "_name": "Weakened"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a509753a-6bac-5c89-b829-2a97c4ecc469",
+          "_name": "Stolen Memories"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9ffd1c61-04d8-5e8c-b8bb-d6aa6bec32dd",
+          "_name": "Depowered"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "10e9cde1-7d44-52c9-9f39-50f7a0f53063",
+          "_name": "Time-Travel Hijinks"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2a6f671c-86af-5283-8d08-a2540bf37431",
+          "_name": "Corrupted Timestream"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 4,
+          "databaseId": "1b5bd4ef-c07c-5655-b058-2fb54e8fb376",
+          "_name": "Kang's Dominion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9d590f40-4b19-504c-aa13-c79ae2220cbc",
+          "_name": "Pinned Down"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3f1a15f3-3389-5b10-9d3a-22b05eb59c5b",
+          "_name": "Rampage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "98af3f41-294d-5d06-be40-f674080187d9",
+          "_name": "Energy Blast"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e20ee2af-3994-5a34-9e1e-0ad7db8875c7",
+          "_name": "Manipulated Timestream"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "afe628ab-d143-5a91-b6be-cd4131db2652",
+          "_name": "Time-Travel Tactics"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9ea8fb08-e0bc-520a-9d5d-412f31a76a0e",
+          "_name": "Past Machinations"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "20bd08e4-e300-5171-a93a-71ffc2398635",
+          "_name": "Kang's Arrival"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "579ff82e-7501-57ac-93d3-26fffcbce00a",
+          "_name": "The Master of Time"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "6d3ab9f2-f8a0-5e2e-a244-29bb6f6652a2",
+          "_name": "The Chronopolis"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Kang"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Deal each player an encounter card"
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$PLAYER_N",
+          "$PLAYER_ORDER",
+          [
+            "ACTION_LIST",
+            "dealEncounterFacedown"
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "DEFINE",
+              "$VILLAIN_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "2531c227-fb70-588e-92a4-e242e60f41e7"
+                ]
+              ]
+            ],
+            [
+              "DELETE_CARD",
+              "$VILLAIN_CARD.id"
+            ],
+            [
+              "DEFINE",
+              "$VILLAIN_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "3ec35abb-ad36-5a9a-88b7-33436c3478fc"
+                ]
+              ]
+            ],
+            [
+              "DELETE_CARD",
+              "$VILLAIN_CARD.id"
+            ],
+            [
+              "DEFINE",
+              "$VILLAIN_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "922092fa-fcdd-50ee-8a4f-37bc68843ee6"
+                ]
+              ]
+            ],
+            [
+              "DELETE_CARD",
+              "$VILLAIN_CARD.id"
+            ],
+            [
+              "DEFINE",
+              "$VILLAIN_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "20d73026-d831-5b50-8d3b-2d2be4bdf0ab"
+                ]
+              ]
+            ],
+            [
+              "DELETE_CARD",
+              "$VILLAIN_CARD.id"
+            ],
+            [
+              "DEFINE",
+              "$VILLAIN_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "8da7c346-63f0-590c-8960-92bd0337787f"
+                ]
+              ]
+            ],
+            [
+              "DELETE_CARD",
+              "$VILLAIN_CARD.id"
+            ],
+            [
+              "DEFINE",
+              "$VILLAIN_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "ebb16bce-3d0e-5a08-a320-14695f3de32f"
+                ]
+              ]
+            ],
+            [
+              "DELETE_CARD",
+              "$VILLAIN_CARD.id"
+            ],
+            [
+              "DEFINE",
+              "$FIRST_STAGE",
+              "I"
+            ],
+            [
+              "LOAD_CARDS",
+              "Expert Kang"
+            ]
+          ]
+        ]
+      ]
+    },
+    "Temporal": {
+      "label": "Temporal",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "0b7bee4f-0c4f-50d8-8838-568a4fe0bdc0",
+          "_name": "Ancient Warrior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "34db0149-ba73-537a-9bb7-5a5f8ceef134",
+          "_name": "Chitauri Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "59681b29-3907-55fd-ac24-360bd3813b26",
+          "_name": "Tyrannosaurus Rex"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "544834e6-6db3-5745-884d-e7067195f789",
+          "_name": "Time Portal"
+        }
+      ]
+    },
+    "Expert Kang": {
+      "label": "Expert Kang",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "e42d48d0-6318-5c51-8177-71f809a14465",
+          "_name": "Kang (The Conqueror)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "19ed000d-59f0-5634-b475-38b4e305cd0c",
+          "_name": "Kang (Immortus)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "24b660ca-1c6d-5844-ab5b-0951c405c49c",
+          "_name": "Kang (Iron Lad)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c95b0992-cfae-59cd-a133-a5cb05e0bbdd",
+          "_name": "Kang (Rama-Tut)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "e3b8febb-b54e-5acc-a738-fba2892949d5",
+          "_name": "Kang (Scarlet Centurion)"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "6786ceac-90c5-5075-8387-aabc0c448754",
+          "_name": "Kang (The Conqueror)"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Anachronauts": {
+      "label": "Anachronauts",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dd66d213-0910-55f7-98f8-1b449520f073",
+          "_name": "Apocryphus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6961eba5-61fe-5c4b-8351-6ba1c83c314f",
+          "_name": "Deathunt 9000"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ef36c20c-c389-5edc-b828-b5aca50dcb0d",
+          "_name": "Sir Raston"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "25c3256e-480a-5b7c-86cf-b32b03c47706",
+          "_name": "Terminatrix"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "11d3e9c8-efa6-54b2-8fa7-1749f2a4441a",
+          "_name": "Wildrun"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b8b1042d-ab64-5f8a-a652-1dabedc62574",
+          "_name": "The Anachronauts"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9cbdb79c-b7a4-5b64-a58c-b0ddd8b4096a",
+          "_name": "Kang's Chosen"
+        }
+      ]
+    },
+    "Master of Time": {
+      "label": "Master of Time",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "07fab77a-6f5f-5920-a4bd-36080c414c92",
+          "_name": "Kang (Master of Time)"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9c817512-3fba-521e-ab92-05f37391f776",
+          "_name": "Time-Displaced Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6129f972-bd61-5062-8991-41b26dcc48aa",
+          "_name": "Fear of Kang"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "250b5ae1-92e0-5a7b-b301-fe374484f282",
+          "_name": "Light of Centuries Sphere"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "06eaede1-6e80-5cea-a381-c71ab9ac7ace",
+          "_name": "Ancient Grudge"
+        }
+      ]
+    },
+    "Ant-Man": {
+      "label": "Ant-Man",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "7a8d1e46-1e6f-5d22-a6eb-6e33bd27c237",
+          "_name": "Ant-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "50b82f30-fb5c-5b22-949f-3c38901b7f6d",
+          "_name": "Wasp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "27e15f3a-a9b0-5c18-9678-1ca03faa11af",
+          "_name": "Giant Stomp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6dc4c231-edaa-5738-a592-b9ea969882d2",
+          "_name": "Hive Mind"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "29549ea6-124d-502e-8129-acd3d6efd528",
+          "_name": "Resize"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "30ca81fe-8315-5b41-baee-639c7f729683",
+          "_name": "Pym Particles"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "eb75ed70-a6c7-5612-aa10-13f8dd43e5be",
+          "_name": "Army of Ants"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2c8b6784-a2c5-517e-917d-16798685d307",
+          "_name": "Ant-Man's Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "dfb75f03-3dc2-5879-92b9-2a06dbf9d32c",
+          "_name": "Giant Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "219f273e-c8aa-509a-a3e4-d4c78287ee80",
+          "_name": "Wrist Gauntlets"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7851e2cb-1fae-5f9d-98ba-488ecdf080e5",
+          "_name": "Ant-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "10b4f980-4b59-5726-b8e8-6c6769c84073",
+          "_name": "Giant-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "77ce9a29-e86e-531a-84ba-2cafb6507e43",
+          "_name": "Ronin"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e93c6de0-fe3f-58db-be24-490856893cbf",
+          "_name": "Stinger"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "dd36911c-e7ca-5d94-bb22-f2c2d3891f4f",
+          "_name": "Call for Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ca2b102a-e5ae-588f-8e77-b8c75751a88b",
+          "_name": "Moxie"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f74421f0-505c-5e47-8b05-8b549fd0cd18",
+          "_name": "Power Gloves"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d61a324b-3403-550e-a689-b1aabf89be5c",
+          "_name": "Reinforced Suit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d823ba4e-6c96-5995-b47e-69da3d8a1c7f",
+          "_name": "Swarm Tactics"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5733abf2-e5a1-5218-8c51-7e4c2f3142de",
+          "_name": "Team-Building Exercise"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "61dae78b-4aa9-57c8-b89c-4250872b7dbb",
+          "_name": "Care for Cassie"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7776c68c-eead-59c0-8d46-864230de9333",
+          "_name": "Tech Theft"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "29f392ce-7c37-533f-a9c4-7ed22cda3744",
+          "_name": "Yellowjacket"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "6721a8d8-998c-5ce8-8a92-3ecabd0f51af",
+          "_name": "Size Increase"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "fbbb2299-ec8a-523a-aedb-962f3ef9da4b",
+          "_name": "Yellowjacket's Plan"
+        }
+      ]
+    },
+    "Ant-Man Nemesis": {
+      "label": "Ant-Man Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7776c68c-eead-59c0-8d46-864230de9333",
+          "_name": "Tech Theft"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "29f392ce-7c37-533f-a9c4-7ed22cda3744",
+          "_name": "Yellowjacket"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "6721a8d8-998c-5ce8-8a92-3ecabd0f51af",
+          "_name": "Size Increase"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "fbbb2299-ec8a-523a-aedb-962f3ef9da4b",
+          "_name": "Yellowjacket's Plan"
+        }
+      ]
+    },
+    "Wasp": {
+      "label": "Wasp",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "84003db4-1b22-5629-9215-fecdf4dee59c",
+          "_name": "Wasp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "951c76bc-4c12-5a60-945d-610a680c550b",
+          "_name": "Ant-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a9bd249a-9dd9-5e1f-8313-6c36984c584c",
+          "_name": "Giant Help"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2bb97272-26fe-572a-87ab-e52b62fb4208",
+          "_name": "Pinpoint Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "cd48d064-96f7-511f-a87c-ae021fc44c8b",
+          "_name": "Rapid Growth"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "066b9229-a06b-523b-a9c5-b884135f37a9",
+          "_name": "Wasp Sting"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "30ca81fe-8315-5b41-baee-639c7f729683",
+          "_name": "Pym Particles"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4da6e803-312e-5a29-97d1-8205a9d320a1",
+          "_name": "Red Room Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d866ba20-3005-550c-aa22-94e37fb61523",
+          "_name": "Bio-Synthetic Wings"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9b11b64d-5b9b-5e4c-b0c9-6a61efafbcb4",
+          "_name": "Wasp's Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "89e080cb-fe4b-5cf2-8887-3cbdfe0f13f8",
+          "_name": "Thor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "17302361-b0d0-5d12-9a60-ec4fc6ff87ed",
+          "_name": "Wasp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ee3bcbb9-c644-5c41-8e42-bffd469992cf",
+          "_name": "Into the Fray"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "12b0727f-acc0-526e-b0b8-de2504604ed2",
+          "_name": "Surprise Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "59897d08-059d-5eed-91eb-e98260dadb8a",
+          "_name": "Boot Camp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "38e870c9-5d03-59dc-b513-57e19aa57d18",
+          "_name": "Lie in Wait"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1e42a35d-fde3-5d47-9a18-a43383a24e11",
+          "_name": "Ironheart"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7c3109eb-034f-547e-a70a-5fcf2fee06d7",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d823ba4e-6c96-5995-b47e-69da3d8a1c7f",
+          "_name": "Swarm Tactics"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "677ed8ce-887b-567d-b2ec-22f2c0ffd5cb",
+          "_name": "The Power in All of Us"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c2c11795-326e-57c3-9712-0e6736d8ac03",
+          "_name": "Quincarrier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c828c026-01a5-5d73-9ab7-63037cb9db83",
+          "_name": "Red Dreams"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "934da0e3-db0c-5eea-ba53-4d3f475fc6b6",
+          "_name": "Mother's Orders"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "68fa97f7-420a-59bd-97a4-2a57d55d3d4c",
+          "_name": "Beetle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ea039f4b-9308-5dd5-875c-fbcdb4521745",
+          "_name": "Beetle Armor MK IV"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "836f1abe-3d2b-5d9d-a195-88ea219f3624",
+          "_name": "Beetle Mania"
+        }
+      ]
+    },
+    "Wasp Nemesis": {
+      "label": "Wasp Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "934da0e3-db0c-5eea-ba53-4d3f475fc6b6",
+          "_name": "Mother's Orders"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "68fa97f7-420a-59bd-97a4-2a57d55d3d4c",
+          "_name": "Beetle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ea039f4b-9308-5dd5-875c-fbcdb4521745",
+          "_name": "Beetle Armor MK IV"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "836f1abe-3d2b-5d9d-a195-88ea219f3624",
+          "_name": "Beetle Mania"
+        }
+      ]
+    },
+    "Quicksilver": {
+      "label": "Quicksilver",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "4d265340-71c9-5754-a056-99e71e86b4e3",
+          "_name": "Quicksilver"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1cdd74b4-ffad-5b89-b9bc-bc677b7817f6",
+          "_name": "Scarlet Witch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 4,
+          "databaseId": "c5e43cd9-91a3-5104-af61-1fb290632278",
+          "_name": "Always Be Running"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "51e17ebe-6cda-5f4a-ae05-073afdb4671f",
+          "_name": "Double Time"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5f8305c3-b49c-537b-bd5e-1544e89bd24f",
+          "_name": "Maximum Velocity"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "52dfb358-e489-5f9d-8ff1-110824cc4814",
+          "_name": "Speed Cyclone"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3b416d58-8de2-5209-ace6-f6a5c03c8f3e",
+          "_name": "Serval Industries"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8673c9b4-8357-5828-90ff-abc7096ec7f7",
+          "_name": "Accelerated Reflex"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c0868511-f576-55fa-98fd-cdb397693378",
+          "_name": "Friction Resistance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4e816df8-b6d4-52e7-80d2-2019b83deaef",
+          "_name": "Hyper Perception"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bca6814c-bdb6-58be-936c-bd17e8c94e8d",
+          "_name": "Reinforced Sinew"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "0a831f4c-b507-58b6-8900-e47976364c42",
+          "_name": "Multiple Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c430d3fc-a8c8-5bdc-9b0b-aea2dc7fb0e5",
+          "_name": "Warlock"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a8d7a1fe-c4d5-5cc4-b4a7-780375aa7d9a",
+          "_name": "Never Back Down"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b50e5539-2e49-5631-94d5-b9fef0d6b3fb",
+          "_name": "Side Step"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b264b5f8-4830-5fc0-a35d-b011f005ece2",
+          "_name": "Armored Vest"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b81c94f5-1de8-5f19-b00f-e9bc8075d848",
+          "_name": "Nerves of Steel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "13d06917-53d6-54b3-9c1b-3fbe795ade7b",
+          "_name": "Order and Chaos"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "deff782b-528f-5f9d-ab57-a4da819e9675",
+          "_name": "Adrenaline Rush"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "95f601f8-28d1-5778-9bf1-0b9550d60145",
+          "_name": "Civic Duty"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "123dea31-26d6-58fa-8ec4-64feee842cd5",
+          "_name": "Need for Speed"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5fb7d482-37ce-57c1-80ec-c23ca80d167c",
+          "_name": "Extortion of Seismic Proportion"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b0b51e3a-4c78-5d8d-b53d-79415c6c5c2c",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "36427cb3-ed51-5d71-acdd-d860a40fcd83",
+          "_name": "Vibration Resistance"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "bb593e7c-8724-5a75-9384-6872f3dcfced",
+          "_name": "Earthquake"
+        }
+      ]
+    },
+    "Quicksilver Nemesis": {
+      "label": "Quicksilver Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5fb7d482-37ce-57c1-80ec-c23ca80d167c",
+          "_name": "Extortion of Seismic Proportion"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b0b51e3a-4c78-5d8d-b53d-79415c6c5c2c",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "36427cb3-ed51-5d71-acdd-d860a40fcd83",
+          "_name": "Vibration Resistance"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "bb593e7c-8724-5a75-9384-6872f3dcfced",
+          "_name": "Earthquake"
+        }
+      ]
+    },
+    "Scarlet Witch": {
+      "label": "Scarlet Witch",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "57b0af03-7f9e-59ce-88f8-31756a2763b8",
+          "_name": "Scarlet Witch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1e8aae9f-c1c1-55ce-b3bf-b5a7de3a9e5b",
+          "_name": "Quicksilver"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "db792ee3-3bc5-5191-b03a-467000ccaa46",
+          "_name": "Chaos Magic"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 4,
+          "databaseId": "58be9ceb-f224-5337-b2ce-5780bbcf7aad",
+          "_name": "Hex Bolt"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ee2b043a-5732-5539-a96f-7a7aee99fb76",
+          "_name": "Molecular Decay"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e74f417e-795c-5a61-9ac2-f79dd7deb353",
+          "_name": "Warp Reality"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1f5a4232-4406-5910-a95d-ef367c3d21c8",
+          "_name": "Agatha Harkness"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "436b3237-a49f-5902-aa4b-d9d869d25e27",
+          "_name": "Magic Shield"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6e6bc1cd-227e-598e-9308-0ffa83073629",
+          "_name": "Scarlet Witch's Crest"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "87544575-ccfd-5c67-a318-6456f22e2439",
+          "_name": "Speed"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1b7b803f-6ba5-5bf7-95bc-e2af25c95255",
+          "_name": "Wiccan"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8759d425-7a58-5fdb-865e-2ab42cd533fb",
+          "_name": "Crisis Averted"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "622b092d-2f91-5dac-a5f6-971c5558899b",
+          "_name": "Multitasking"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5d8ab240-c894-5321-9af6-cf8c71cee612",
+          "_name": "Swift Retribution"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c091778a-3288-58b6-969b-1d2f1f440b8b",
+          "_name": "Turn the Tide"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "beba6d45-629f-55c9-94cf-3568c144eb6b",
+          "_name": "The Power of Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5d841847-94a8-5ff4-968a-fdbe5d4af9cd",
+          "_name": "Heroic Intuition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "13d06917-53d6-54b3-9c1b-3fbe795ade7b",
+          "_name": "Order and Chaos"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5f838c37-3f9e-5b87-b7ed-2a1daba4e17c",
+          "_name": "Spiritual Meditation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "10ce750e-7581-515a-a02b-6375b3ca1d47",
+          "_name": "Slipping Sanity"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0cc0edc8-35eb-53b9-bb20-40d30366f20d",
+          "_name": "The Next Evolution"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c3950111-c45b-58da-a552-8b7220004550",
+          "_name": "Luminous"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a9620606-7e6b-5eb6-8034-297a612d2c0a",
+          "_name": "Magical Suspension"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "656abd7c-fde7-5c1e-95cf-54df63f251a6",
+          "_name": "Chaos Manipulation"
+        }
+      ]
+    },
+    "Scarlet Witch Nemesis": {
+      "label": "Scarlet Witch Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0cc0edc8-35eb-53b9-bb20-40d30366f20d",
+          "_name": "The Next Evolution"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c3950111-c45b-58da-a552-8b7220004550",
+          "_name": "Luminous"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a9620606-7e6b-5eb6-8034-297a612d2c0a",
+          "_name": "Magical Suspension"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "656abd7c-fde7-5c1e-95cf-54df63f251a6",
+          "_name": "Chaos Manipulation"
+        }
+      ]
+    },
+    "Groot": {
+      "label": "Groot",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "821b3a2a-38d9-5861-b55f-df9b283d3133",
+          "_name": "Groot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "abd5c1ca-3a7f-56ea-b17a-79ca0117258d",
+          "_name": "Fruition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d5d6ea3a-4c21-5f42-a2ba-7a2e69312652",
+          "_name": "\"I Am Groot\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e7647b3c-d9ff-5a4a-a068-0d1cd7693c29",
+          "_name": "\"I. AM. GROOT!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5100db89-8940-5f90-a11c-7dd50b72b6d7",
+          "_name": "Root Stomp"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "da957c8e-1d57-547c-a804-0c23b375d913",
+          "_name": "\"We Are Groot\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c3089a4b-4709-5dbb-843c-f2f245f84b36",
+          "_name": "Fertile Ground"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ee389174-5356-5093-94ab-abfac16f8fab",
+          "_name": "Entangling Vines"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f7cb6318-43a4-5d86-ac7b-0a78898d8e57",
+          "_name": "Lashing Vines"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "acc3ccdf-7d47-55c0-a984-56e39062f676",
+          "_name": "Vine Shield"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "833700ed-e306-59f2-8849-c957447274f6",
+          "_name": "Vine Spikes"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "33d94dcd-e6aa-52d8-8a24-3b81abab0b99",
+          "_name": "Starhawk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "707bd795-e84b-5d05-94c2-cf39aa316849",
+          "_name": "Desperate Defense"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "53577797-52ea-5d3f-a33c-aa53499ca63b",
+          "_name": "Fighting Fit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4f8dd69d-4555-5af5-b48f-709a73d6acea",
+          "_name": "The Power of Protection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8c21bc95-6998-5d8c-b935-cf24caf79a2e",
+          "_name": "Dauntless"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "342cb7e4-374f-520e-870f-461145a941de",
+          "_name": "Hard to Ignore"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bd2f6e16-7074-5a7f-9519-ced58f280310",
+          "_name": "Indomitable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "371960a7-13ff-55de-a177-0904629326c3",
+          "_name": "Rocket Raccoon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b8d5e3b9-7c98-5dd1-81f8-c6afdc9a1fd7",
+          "_name": "Flora and Fauna"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7454476e-1d2d-5fae-98ca-b2fd87649229",
+          "_name": "Deft Focus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "47ea2afb-99e5-5e49-bea7-a10c67c77a5f",
+          "_name": "Wilt"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "724eabdc-4fba-57fe-b480-6b6c8564e445",
+          "_name": "Blazing Inferno"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13036687-3523-56f9-a505-3a1b1acb7031",
+          "_name": "Furnax"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "3eda870c-66c8-5ab5-b12a-0259678d9857",
+          "_name": "Fan the Flames"
+        }
+      ]
+    },
+    "Groot Nemesis": {
+      "label": "Groot Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "724eabdc-4fba-57fe-b480-6b6c8564e445",
+          "_name": "Blazing Inferno"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13036687-3523-56f9-a505-3a1b1acb7031",
+          "_name": "Furnax"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "3eda870c-66c8-5ab5-b12a-0259678d9857",
+          "_name": "Fan the Flames"
+        }
+      ]
+    },
+    "Rocket Raccoon": {
+      "label": "Rocket Raccoon",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "7813ba7d-e03e-5fc4-b6d6-cb3e04423577",
+          "_name": "Rocket Raccoon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3ccebf4b-19b8-5083-b6da-d0a3b5afa016",
+          "_name": "I've Got a Plan"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "870dccc3-6552-5f82-854d-657eee3868c4",
+          "_name": "Reload"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "be24735e-c60d-5c61-bab3-ed19a569dd42",
+          "_name": "Schadenfreude"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e0131772-6685-5e75-8a43-2b6dbb59da00",
+          "_name": "Salvage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "42898729-8e19-55f1-a5a3-70342810e699",
+          "_name": "Battery Pack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "01ed5409-80b1-5d3e-8514-2312b3ad239d",
+          "_name": "Cybernetic Skeleton"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c29bb6fb-2265-5250-b4d4-8be7b97398f3",
+          "_name": "Particle Cannon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a1bea7ce-0630-50b9-9bc8-22ac872d1f3a",
+          "_name": "Rocket Launcher"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ed9fca77-81fb-56a2-a9bc-58996f61a77c",
+          "_name": "Rocket's Pistol"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c7f034d8-a92b-5c05-9310-a4137716c63d",
+          "_name": "Thruster Boots"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bc66abe3-e41b-5827-86eb-01f7443cb1dc",
+          "_name": "Bug"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b7b48c3f-99e2-5e32-82b5-3f6f7b955781",
+          "_name": "Chase Them Down"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ee3bcbb9-c644-5c41-8e42-bffd469992cf",
+          "_name": "Into the Fray"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "17b03d4b-0553-5fad-941e-fe9caa7a027c",
+          "_name": "Looking for Trouble"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a6671bdc-87c8-5d93-bb74-ef3f4c748e43",
+          "_name": "Relentless Assault"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "1f54d7ff-4963-5269-809e-7bff86185abe",
+          "_name": "Follow Through"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6211ca68-12a1-51c6-85f8-58c16b21da13",
+          "_name": "Hand Cannon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "39f75d7a-40d0-5d32-b7ce-797dfc1b9980",
+          "_name": "Groot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b8d5e3b9-7c98-5dd1-81f8-c6afdc9a1fd7",
+          "_name": "Flora and Fauna"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9799b4f1-bf19-5dbd-9f0f-6571f0ca185f",
+          "_name": "Booster Boots"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b1027be1-0816-5c49-9253-d6a81546a72a",
+          "_name": "Crisis on Halfworld"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "55d3f010-0919-51f4-9f51-a60ad665b7e1",
+          "_name": "Vendetta"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "15394fd3-686d-54e0-b7a0-ce25fe119dea",
+          "_name": "Blackjack O'Hare"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0cbaccc6-628d-5563-ad90-76ffb2036be1",
+          "_name": "Blackjack's Bazooka"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "f064bccc-a091-5094-a720-84d780e6f5cb",
+          "_name": "Planetary Invasion"
+        }
+      ]
+    },
+    "Rocket Raccoon Nemesis": {
+      "label": "Rocket Raccoon Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "55d3f010-0919-51f4-9f51-a60ad665b7e1",
+          "_name": "Vendetta"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "15394fd3-686d-54e0-b7a0-ce25fe119dea",
+          "_name": "Blackjack O'Hare"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0cbaccc6-628d-5563-ad90-76ffb2036be1",
+          "_name": "Blackjack's Bazooka"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "f064bccc-a091-5094-a720-84d780e6f5cb",
+          "_name": "Planetary Invasion"
+        }
+      ]
+    },
+    "Brotherhood of Badoon": {
+      "label": "Brotherhood of Badoon",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "8b8dd9f2-3848-5cda-ac0b-dd9999c60965",
+          "_name": "Drang"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "e68b46a7-278a-5f0b-887d-fe9b79e4f70a",
+          "_name": "Drang"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "83b48cb8-99e2-558b-b1e1-bb73e48b1983",
+          "_name": "Drang"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "7ea3fcc7-e18f-5d12-a6b9-9210a027a879",
+          "_name": "Terrestrial Invasion"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "ee64ff02-1f04-5fdb-929a-6292c239ebb4",
+          "_name": "Protect the Planet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e2c90c2d-1cb8-5b51-aac7-b58b24b4737f",
+          "_name": "Badoon Ship"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0802bd86-42da-56af-8d4d-b8736aa7b1c7",
+          "_name": "Drang's Spear"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9af4e3cf-0156-513c-bf6c-df8348f8ca40",
+          "_name": "Badoon Engineer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "57de7888-5468-55a6-b932-39d2626637ee",
+          "_name": "Blockade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "df128876-cc92-57d6-86ad-cf8f6f01f778",
+          "_name": "Bombardment"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "424b0241-e6e8-5232-be6c-c58dc500198e",
+          "_name": "Oppressive Armada"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f41b81bb-b788-5f7d-b468-f31918390846",
+          "_name": "Spatial Positioning"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Brotherhood of Badoon"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Brotherhood of Badoon"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Put \"Badoon Ship\" into play"
+        ],
+        [
+          "DEFINE",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "e2c90c2d-1cb8-5b51-aac7-b58b24b4737f"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "COND",
+          "$GAME.loadRequired",
+          [
+            [
+              "LOG",
+              "Setup: Put \"Milano\" into play"
+            ],
+            [
+              "DEFINE",
+              "$ENV_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "ad8439f9-b46e-5aa6-9f79-4184c8c033f3"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$ENV_CARD.id",
+              "player1Play1",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Setup: Reveal \"Drang's Spear\""
+            ],
+            [
+              "DEFINE",
+              "$ENV_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "0802bd86-42da-56af-8d4d-b8736aa7b1c7"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$ENV_CARD.id",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ]
+      ]
+    },
+    "Infiltrate the Museum": {
+      "label": "Infiltrate the Museum",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "4df82aec-08a1-5fd6-9ef1-0f88be027e37",
+          "_name": "Collector"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d3791138-b5b9-5c7e-bc34-d7d13b83eb93",
+          "_name": "Collector"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "282ec132-f8c4-53ac-b46f-82ba7f4899d4",
+          "_name": "Collector"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "1ede4b88-f989-5f27-973d-efc6ce08b45f",
+          "_name": "The Grand Collection"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "154b1029-327a-58af-b418-8fc84fdff683",
+          "_name": "Biogram Image"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "31d5ce4c-6d6e-5e32-9b23-f4855d892d02",
+          "_name": "Monark Starstalker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0d09e04f-4d47-5ab2-87b4-e28e33233644",
+          "_name": "Inconspicuous Box"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "bfa861d5-b5d4-5b2d-9cef-20d66b65f406",
+          "_name": "View the Cosmos"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f8298f1b-a120-5377-a8db-cba8bf0244c3",
+          "_name": "Stay Awhile"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6ab0790a-4b0c-578b-a2a7-b450da3fd794",
+          "_name": "Caught Off Guard"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Infiltrate the Museum"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Infiltrate the Museum"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Escape the Museum": {
+      "label": "Escape the Museum",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "482e1911-35a0-541e-ae8a-119a157cef23",
+          "_name": "Collector"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7f240977-74bb-50bb-827e-5070868a27af",
+          "_name": "Collector"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "f74fa9ea-fa0d-592d-8dd6-50d73754c9dd",
+          "_name": "The Missing Milano"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "f8970ca4-17d2-5ada-9b89-cad165a2d921",
+          "_name": "Lost in the Museum"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "253bc8e2-1187-5647-bf6c-1d8a8059def0",
+          "_name": "The Great Escape"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0ea8662a-1c1f-5306-8633-09a4cdfb7ad1",
+          "_name": "Library Labyrinth"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "0a14b2a5-63a6-5726-babb-0cfecc1ed891",
+          "_name": "\"I Have You Now!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "e0659d98-ab97-5b9b-ac3c-5e3f32416fbe",
+          "_name": "Impossible Geometry"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Escape the Museum"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Escape the Museum"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Put \"Library Labyrinth\" into play"
+        ],
+        [
+          "DEFINE",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "0ea8662a-1c1f-5306-8633-09a4cdfb7ad1"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ]
+      ]
+    },
+    "Nebula (Scenario)": {
+      "label": "Nebula (Scenario)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f5a6cc7d-7bee-5665-9e63-6c92a9a6bda2",
+          "_name": "Barrel Roll"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1698ac3e-ce36-50fd-a511-b6a3a52d24ed",
+          "_name": "Combat Ready"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1767d71e-bb2a-5814-b37f-2bc960b9647f",
+          "_name": "Ruthless"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7e4e0be0-a452-5618-bc69-74078c43ec3c",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "ce5ab59f-d4de-5fc8-91e1-30cdd37ea57d",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "45785295-b3d8-53c5-a7ea-24f7af5ceac7",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "50216771-b87d-5b6d-9be6-74524778e889",
+          "_name": "The Art of Evasion"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "e156031b-721d-51bd-8201-1e16ed5ec1f0",
+          "_name": "Warp Drive Initiated"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c9815d46-386b-546f-be50-f29ae87719e3",
+          "_name": "Nebula's Ship"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "e04ae3ad-d641-50c2-b823-21ab2830ebcc",
+          "_name": "Cutthroat Ambition"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7ee1417e-9304-5d10-942e-91197cc91bfe",
+          "_name": "Evasive Maneuvering"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fa842bbd-a146-5f8a-8dbb-225e388c9065",
+          "_name": "Unyielding Persistence"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "bac4255f-0793-5c50-9fa2-3fc50335edac",
+          "_name": "Weapon Mastery"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d66d2223-d373-5f45-a681-d5b14fafebfb",
+          "_name": "Wide Stance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5657e647-9fba-596d-ac12-4c88448ef117",
+          "_name": "Lethal Intent"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Nebula"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Nebula"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Put \"Nebula's Ship\" into play"
+        ],
+        [
+          "DEFINE",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "c9815d46-386b-546f-be50-f29ae87719e3"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "COND",
+          "$GAME.loadRequired",
+          [
+            [
+              "LOG",
+              "Setup: Put \"Milano\" into play"
+            ],
+            [
+              "DEFINE",
+              "$ENV_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "ad8439f9-b46e-5aa6-9f79-4184c8c033f3"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$ENV_CARD.id",
+              "player1Play1",
+              -1
+            ],
+            [
+              "LOG",
+              "Setup: Attach \"Power Stone\" to Nebula"
+            ],
+            [
+              "DEFINE",
+              "$ENV_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "77738a60-281e-5bf9-bc1a-456d2dd4cb69"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$ENV_CARD.id",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ],
+        [
+          "LOG",
+          "Setup: Discard 2 per player cards and attach each TECHNIQUE"
+        ],
+        [
+          "FOR_EACH_START_STOP_STEP",
+          "$i",
+          0,
+          [
+            "MULTIPLY",
+            2,
+            "$GAME.numPlayers"
+          ],
+          1,
+          [
+            [
+              "DEFINE",
+              "$CARD",
+              "$GAME.groupById.sharedEncounterDeck.parentCards.[0]"
+            ],
+            [
+              "COND",
+              [
+                "IN_STRING",
+                "$CARD.sides.A.traits",
+                "Technique"
+              ],
+              [
+                "MOVE_CARD",
+                "$CARD.id",
+                "sharedVillain",
+                -1
+              ],
+              true,
+              [
+                "MOVE_CARD",
+                "$CARD.id",
+                "sharedEncounterDiscard",
+                0
+              ]
+            ]
+          ]
+        ]
+      ]
+    },
+    "Ronan the Accuser": {
+      "label": "Ronan the Accuser",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "0064d55e-4bce-5002-bd86-d6611dceff2a",
+          "_name": "Ronan the Accuser"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3dfebee6-5d75-5ae4-b066-77936344d27c",
+          "_name": "Ronan the Accuser"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3ef39526-b91d-58c0-aaf7-6476e1ba5db0",
+          "_name": "Ronan the Accuser"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "407fc962-a197-5a78-a3b8-8b5e886e4e33",
+          "_name": "Interception Imminent"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "7ed8ce33-c7f5-56b1-a37f-6cf996fcd787",
+          "_name": "\"Take What Is Mine\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e8c2bd87-310b-5573-a67d-a5617120ee60",
+          "_name": "Kree Command Ship"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a00d6e1b-ebd0-5c8d-9f0f-5bf61e2b4953",
+          "_name": "Universal Weapon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f49cc591-001f-51c6-86ab-cbcaeefb08d1",
+          "_name": "Fanaticism"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5e7cfaa7-a4a6-5d1d-9794-40868aa86ffd",
+          "_name": "Cut the Power"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "25e84759-16e7-594f-b2f5-150ed26b8fb2",
+          "_name": "Pincer Maneuver"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "aa5367a0-9979-59dc-a7f5-80e11bee1ba6",
+          "_name": "Superior Tactics"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8bbca99e-435d-5116-855f-2247e0385551",
+          "_name": "Single-Minded Fury"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "38f6e2a4-5f25-5da0-b5a9-2aa8da3fc65f",
+          "_name": "Kree Physiology"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "d183bb13-e65d-5244-a6b0-87e30ac112aa",
+          "_name": "\"You Stand Accused!\""
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Ronan the Accuser"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Ronan the Accuser"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "LOG",
+          "Setup: Put \"Kree Command Ship\" into play"
+        ],
+        [
+          "DEFINE",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "e8c2bd87-310b-5573-a67d-a5617120ee60"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "LOG",
+          "Setup: Attach \"Universal Weapon\" to Ronan"
+        ],
+        [
+          "DEFINE",
+          "$ATTACHMENT_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "a00d6e1b-ebd0-5c8d-9f0f-5bf61e2b4953"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ATTACHMENT_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "COND",
+          "$GAME.loadRequired",
+          [
+            [
+              "LOG",
+              "Setup: Put \"Milano\" into play"
+            ],
+            [
+              "DEFINE",
+              "$MILANO_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "ad8439f9-b46e-5aa6-9f79-4184c8c033f3"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$MILANO_CARD.id",
+              "player1Engaged",
+              -1
+            ],
+            [
+              "LOG",
+              "Setup: Attach \"Power Stone\" to 1st player"
+            ],
+            [
+              "DEFINE",
+              "$POWER_STONE_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "ad8439f9-b46e-5aa6-9f79-4184c8c033f3"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$POWER_STONE_CARD.id",
+              "player1Engaged",
+              -1
+            ]
+          ]
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            [
+              "LOG",
+              "Reveal \"Cut the Power\""
+            ],
+            [
+              "DEFINE",
+              "$SIDE_SCHEME_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "EQUAL",
+                  "$CARD.databaseId",
+                  "5e7cfaa7-a4a6-5d1d-9794-40868aa86ffd"
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$SIDE_SCHEME_CARD.id",
+              "sharedVillain",
+              -1
+            ]
+          ]
+        ]
+      ]
+    },
+    "Band of Badoon": {
+      "label": "Band of Badoon",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4e361b30-f822-56fd-9c36-e3ef83c5ecc3",
+          "_name": "Badoon Assassin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "e18fd678-5f21-5737-b08e-8c6da2f0d780",
+          "_name": "Badoon Grunt"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "45f764b6-3df9-5e64-b781-c3960e53127c",
+          "_name": "Badoon Lieutenant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0339330e-bf11-534f-a73e-7b1e8a8a075a",
+          "_name": "Badoon Sentry"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f0ed5670-d3c0-5cc3-baed-f5710afcb9a7",
+          "_name": "Badoon Warlord"
+        }
+      ]
+    },
+    "Galactic Artifacts": {
+      "label": "Galactic Artifacts",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e2781ad-cb6c-546c-8790-d31fdab51cd9",
+          "_name": "Cloak of Hercules"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "25771d4b-4583-59cb-883e-d66b495ebf27",
+          "_name": "Obedience Potion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f98ea4b-e39e-5b9e-89d2-f22d4478c161",
+          "_name": "The Beyonder's Blazer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "30139e24-5eb9-5c7b-a931-c32990848aa7",
+          "_name": "The Poison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "81c9beda-77ae-5580-8f7c-eb542adfefbd",
+          "_name": "Vandarian Power Wand"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a313f69a-3e25-5040-907c-399e26716a79",
+          "_name": "Hujahdarian Monarch Egg"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0f75a3ea-da2a-5f33-97f3-e1bb05971a83",
+          "_name": "Magical Teapot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3c23b60f-cb20-55a2-be54-466530103845",
+          "_name": "Philosopher's Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3bb60999-05dd-5260-b52e-2830b8a0ca20",
+          "_name": "Crystal Ball"
+        }
+      ]
+    },
+    "Kree Militants": {
+      "label": "Kree Militants",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "82c62c7c-0df9-51a6-8b23-c831cb1c84b1",
+          "_name": "Kree Combat Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "7adeb1b6-a442-55ca-b3c4-8ba67f983e26",
+          "_name": "Kree Commando"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3750b2a1-c595-5d9c-8b06-8b28191d9932",
+          "_name": "Kree Lieutenant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "c0b2f9e7-d0cd-50e8-a91f-39351495fa04",
+          "_name": "Kree Private"
+        }
+      ]
+    },
+    "Menagerie Medley": {
+      "label": "Menagerie Medley",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "55bc4a36-12d8-57d8-97a4-d58d62003018",
+          "_name": "Psionic Ghost"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "6a27c000-a39f-5836-8db7-986b8f30830b",
+          "_name": "Servant Bot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3b6aa2e3-8dca-58fe-b19f-e088edce121a",
+          "_name": "Starshark"
+        }
+      ]
+    },
+    "Space Pirates": {
+      "label": "Space Pirates",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "823e143f-f7fc-5483-a90b-16d71f86819d",
+          "_name": "Pirate Commander"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "d3637349-a7ee-5352-b90b-8c68281be9b9",
+          "_name": "Pirate Lackey"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3fbe1bb9-e2c7-5577-9317-94c09285c805",
+          "_name": "Sound the Alarms"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b259ede2-3035-50d0-a562-361306ee6f26",
+          "_name": "Honor Among Thieves"
+        }
+      ]
+    },
+    "Ship Command": {
+      "label": "Ship Command",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ad8439f9-b46e-5aa6-9f79-4184c8c033f3",
+          "_name": "Milano"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a7c220fb-0135-51fa-91da-df3a5ef922bc",
+          "_name": "Rogue Vessel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db42a59c-452b-5001-a030-4477ff5a371f",
+          "_name": "Cannonade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f1f6c1c-dac1-5ba8-8270-74b81e5e4d23",
+          "_name": "Blind Side"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c215e7-3f21-5edc-8ab0-c7d2af5548aa",
+          "_name": "Hull Breach"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2afe6621-12bc-5f71-bc72-b0859ddae29d",
+          "_name": "Power Siphon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "538950af-1642-54fa-ba20-befffb3e327e",
+          "_name": "Special Delivery"
+        }
+      ]
+    },
+    "Power Stone": {
+      "label": "Power Stone",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "77738a60-281e-5bf9-bc1a-456d2dd4cb69",
+          "_name": "Power Stone"
+        }
+      ]
+    },
+    "Campaign - The Market": {
+      "label": "Campaign - The Market",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1c6bdc89-2c6c-52a2-a888-7e805eee6f4f",
+          "_name": "Brainstorm"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1e6c5cab-8cc9-5336-93f7-43a3a5714812",
+          "_name": "By Any Means"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "32fe8f77-9b1a-545f-918c-991808eee4d5",
+          "_name": "Contingency Plan"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "5fc96494-8ec9-5edb-b82c-c8c0a483d2d6",
+          "_name": "In Defiance"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "2684760e-43fe-590f-906e-bdb0b2d79be6",
+          "_name": "Calculate the Odds"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "71dceacd-9d43-50a8-8b2f-3735a0676099",
+          "_name": "Creative Solution"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "d6701fff-ae94-50ae-b64a-a0465081a210",
+          "_name": "Grapple"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "a38e5bbc-30a2-5fd2-892b-11e08ffe9257",
+          "_name": "Wing It"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "430214d3-ca7a-5fd9-b8f9-ea7bc3e863de",
+          "_name": "Close Call"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6465b94d-e0c0-5c5a-b824-00057df0dafd",
+          "_name": "Defy Danger"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "903bc092-e171-5157-9e13-b3fad57959e8",
+          "_name": "In Harm's Way"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "8d60ffcd-ef61-5d36-9879-a322b2c102d4",
+          "_name": "Take the Fight to Them"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "5d3e8866-0cc4-551a-8ee4-9a4d9e1fa432",
+          "_name": "Armor Plating"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "17092f07-5313-57e8-9137-0560abc2d1fa",
+          "_name": "Heavy Cannon"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6d3808f1-2d33-57fa-8381-9942da9b6004",
+          "_name": "Hyper Thrusters"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "85985647-fbaf-5ffc-bfdf-1684ce996f6d",
+          "_name": "Reactor Core"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c04d8b21-2d9f-5a0e-ab52-7e823266344c",
+          "_name": "Ardent Resolve"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "d2e58f0a-8400-51c2-bcd9-a96b7c169efd",
+          "_name": "Onrush"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c883c7c0-ae20-513a-996f-73d3df88adce",
+          "_name": "Safeguard"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "4058b4a0-6190-5d62-a362-2c18193a796f",
+          "_name": "Sure Gamble"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "cb27dc95-7173-51e0-9276-37bb2cb6b368",
+          "_name": "Cargo Hold"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "92be99c7-0c30-5c69-a5f8-6c3aa02e0d25",
+          "_name": "Mounted Laser"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "0ffa65c8-4951-5fc6-b737-f2129e6ee7b6",
+          "_name": "Navigation Column"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1e136146-d792-5bd8-9ea3-46ddeb22ca50",
+          "_name": "Targeting Screen"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "24975c00-c81c-5a1b-880f-13c17193869d",
+          "_name": "Grand Strategy"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6e3064ba-2de3-5186-9ff1-586844acda52",
+          "_name": "Power Unleashed"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "78b5eb7e-bfaa-5969-a447-bad666d078f0",
+          "_name": "Tried and True"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "7cdf77c4-cd4a-58fa-a53d-3be964333538",
+          "_name": "Triple Threat"
+        }
+      ]
+    },
+    "Campaign - Expert Challenge": {
+      "label": "Campaign - Expert Challenge",
+      "cards": []
+    },
+    "Campaign - Standard Challenge": {
+      "label": "Campaign - Standard Challenge",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "7d71a92c-d49f-584d-8ec6-06528c123cb3",
+          "_name": "Badoon Blitz"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "308e9bd6-d1af-5c10-b264-ce39af52484a",
+          "_name": "Gallery of Splendor"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "d9594c2a-54f0-5605-945a-6f2b18b564f7",
+          "_name": "\"There Is No Escape\""
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "991ded4b-b326-5929-b26a-49b7b442ccfb",
+          "_name": "Guerrilla Tactics"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "a3031c78-00f8-58ce-bbdd-8b37296ee7f3",
+          "_name": "Kree Supremacy"
+        }
+      ]
+    },
+    "Badoon Headhunter": {
+      "label": "Badoon Headhunter",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "26b46d84-5266-567f-8445-f90788b42141",
+          "_name": "Badoon Headhunter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "495aae9b-14c1-55bc-bdf3-c733f6594c87",
+          "_name": "On the Hunt"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b23bff50-0aee-51d4-a1a3-56b377e24b72",
+          "_name": "Dead to Rights"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "312952bd-a7d7-5782-bc1e-7ac90a7e1843",
+          "_name": "Headhunter's Henchman"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4c9432d7-9363-5e3a-bd3f-8da79b5ff759",
+          "_name": "Fugitive Recovery"
+        }
+      ]
+    },
+    "Star-Lord": {
+      "label": "Star-Lord",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "0984f881-1809-5e4d-9673-afe8fde7de86",
+          "_name": "Star-Lord"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4ad9dd9e-17e6-55c1-9169-c9de35844f89",
+          "_name": "Nova Prime"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6b878de0-d91b-5eda-9a90-cc72fbc8f9f0",
+          "_name": "Daring Escape"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fbed6dc8-b079-5881-b199-328151a4da7d",
+          "_name": "Gutsy Move"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c3db4bee-20fe-55ff-ab6c-1ff3eb3aa3e0",
+          "_name": "Sliding Shot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a68aed7d-0c61-5997-a5ba-73ccaed8e67e",
+          "_name": "Bad Boy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2ccba957-993a-5a13-abf6-a4c24dc3c3c2",
+          "_name": "Element Gun"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d76a2a50-6ce8-54f4-8e02-022e40cffc2f",
+          "_name": "Jet Boots"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f2d967ae-3ff4-548b-8833-dcfef444f039",
+          "_name": "Leader of the Guardians"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c6f8826a-dd43-5c2b-b721-e95e6719f6d1",
+          "_name": "Star-Lord's Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "92e2cd77-5efc-5ba6-9306-f056fbe6d57e",
+          "_name": "Adam Warlock"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "26ead999-57a2-5781-b414-f23fb46fd75a",
+          "_name": "Beta Ray Bill"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f7ba891e-53d1-55f3-bd24-842cf364d748",
+          "_name": "Yondu"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "1b7156c2-385c-571a-a646-8ed7bb46bd52",
+          "_name": "Air Supremacy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "67f7da50-9cdc-5c33-a521-58ea20dea6fb",
+          "_name": "Blaze of Glory"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d6cd8844-cc7b-5ef8-9885-712b3b0baf80",
+          "_name": "Get Ready"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d0b678f4-7fab-56ed-aae1-4de799674f77",
+          "_name": "Target Practice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "04fe3e79-279a-5d4b-93f4-bf6fa562e825",
+          "_name": "The Power of Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2935f50a-766a-500e-9031-e7aa6adf0adc",
+          "_name": "Laser Blaster"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "036a02f6-89d6-566c-b50c-8e29b76864e0",
+          "_name": "Cosmo"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b849e608-ed6f-54ad-b583-e5d323c79393",
+          "_name": "C.I.T.T."
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "62f627c7-a5b6-50ce-b9c0-7fadd1aa222e",
+          "_name": "Knowhere"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "038c225a-f95e-569a-a733-d81f2e701ec7",
+          "_name": "Pulse Grenade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9244f1fa-5e7c-59f4-95ef-fe976348c975",
+          "_name": "Banishment"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dfa846f0-12f1-5238-b0d0-c87012e47907",
+          "_name": "Budding Crime Syndicate"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3d49a40f-2e39-5af1-9e18-c008923407dd",
+          "_name": "Mister Knife"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "0c7a07de-ed17-5d46-a3d4-5bf602dedfbc",
+          "_name": "Spartoi Cunning"
+        }
+      ]
+    },
+    "Star-Lord Nemesis": {
+      "label": "Star-Lord Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dfa846f0-12f1-5238-b0d0-c87012e47907",
+          "_name": "Budding Crime Syndicate"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3d49a40f-2e39-5af1-9e18-c008923407dd",
+          "_name": "Mister Knife"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "0c7a07de-ed17-5d46-a3d4-5bf602dedfbc",
+          "_name": "Spartoi Cunning"
+        }
+      ]
+    },
+    "Gamora": {
+      "label": "Gamora",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "98d86313-9f19-545f-9ae2-183ed96aeb17",
+          "_name": "Gamora"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e6d6e5a3-cc17-50ae-9ebe-abbd34fb23b1",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "6a37dcd1-7a01-5fc6-b819-f5d50ab9f2c3",
+          "_name": "Acrobatic Move"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b4c54db3-3ac7-56ae-8e47-c72bbed17f30",
+          "_name": "Crosscounter"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "f42d6742-e91d-59fa-b8f8-2783b9d9b62f",
+          "_name": "Set the Pace"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d706b221-d153-56c1-8c1f-1a996e3126c9",
+          "_name": "Decisive Blow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5b41cbfc-d624-5006-897d-b3c1480bc8b4",
+          "_name": "Forward Momentum"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6566c60d-e8ae-5b61-8730-78bf5c3fa57c",
+          "_name": "Conditioning Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d8d29b57-1973-59c6-a7be-33d3174d056c",
+          "_name": "Keen Instincts"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "71413fbe-847b-56aa-9add-4a3c58502850",
+          "_name": "Gamora's Sword"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e213147a-281a-5ce9-a50b-2298219f53af",
+          "_name": "Angela"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d9ba57fb-c678-5559-9c5f-1d4101e68e35",
+          "_name": "Clobber"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "da60e4e0-ddf5-5929-829f-3455278e79c3",
+          "_name": "Plan of Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "52ce4abf-f0bb-5144-ad68-4b27917d65e6",
+          "_name": "Uppercut"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "1ca56cad-7e41-5ed3-80cc-45ea9bfc11aa",
+          "_name": "First Hit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "dcf24eba-dc7a-5997-a41d-2779f21ff3eb",
+          "_name": "Impede"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3c8506e5-d29c-5c9c-81b8-ee0f47e91ea0",
+          "_name": "Combat Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d97a64fa-fd31-598f-b943-05a101c5c036",
+          "_name": "Godslayer"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e151adc6-89a1-5e45-8fbf-27b07139a65e",
+          "_name": "Drax"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "4ebf9090-b8ac-597f-8f90-3b41e308b653",
+          "_name": "Hit and Run"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ef19ca05-f38f-5a6c-8ecf-8f1c2326d1bc",
+          "_name": "Unfulfilled Destiny"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0191e363-3fbf-5647-96c1-ee7fd78f9932",
+          "_name": "Sibling Rivalry"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2ca9ae57-070d-51b7-8377-978ca0d78dd1",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4226b99c-4c08-5d6e-9d08-78218c64d085",
+          "_name": "In a Bind"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0d815c4a-0684-5894-a78c-400d3b6d3df8",
+          "_name": "Waylay"
+        }
+      ]
+    },
+    "Gamora Nemesis": {
+      "label": "Gamora Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0191e363-3fbf-5647-96c1-ee7fd78f9932",
+          "_name": "Sibling Rivalry"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2ca9ae57-070d-51b7-8377-978ca0d78dd1",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4226b99c-4c08-5d6e-9d08-78218c64d085",
+          "_name": "In a Bind"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0d815c4a-0684-5894-a78c-400d3b6d3df8",
+          "_name": "Waylay"
+        }
+      ]
+    },
+    "Drax": {
+      "label": "Drax",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "6a1bc4e2-54b9-587e-b68b-a82513c3392f",
+          "_name": "Drax"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f0b8451d-f1ba-507c-8c3d-4b5835dd4ad9",
+          "_name": "Mantis"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "cc3c62a5-735d-5b70-92b9-76a89f0104c4",
+          "_name": "\"Fight Me, Coward!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9efb1bed-bf9e-5dad-9fdd-23a08fe05146",
+          "_name": "Intimidation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d51796f8-6715-5840-9729-39a797ceddbd",
+          "_name": "Knife Leap"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "39c96343-8d20-58d7-b373-9db684061c6e",
+          "_name": "Parry"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a10d18d8-c438-5c1c-958e-8b40de9b9980",
+          "_name": "Payback"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "637403a5-10b8-5670-ac2b-61de7999730f",
+          "_name": "Drax's Knife"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cb730260-8d74-513b-9b16-4745fccb124b",
+          "_name": "Drax's Other Knife"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e0eac2ee-ec1b-584c-970e-d5107e1973cc",
+          "_name": "Dwi Theet Mastery"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f58fb863-11bc-5a76-8ed8-fbbf6116f335",
+          "_name": "Too Stubborn to Die"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ed974873-14f1-58f3-8da1-6c9953d7b44d",
+          "_name": "Martyr"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "22a34248-5eb4-595a-aceb-1563e884291c",
+          "_name": "Moondragon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b90b259b-916b-5e38-b454-929125397d2c",
+          "_name": "Counter-Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8c9e1f34-275d-5af2-a2dc-2f7b19668cd9",
+          "_name": "Deflection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6be2eae6-d2d5-5baf-80af-2fa9fa331bba",
+          "_name": "Hard Knocks"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "53543adc-6897-52d3-9b46-fab0fdad13af",
+          "_name": "Leading Blow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "298d9a13-d5b7-5f33-8220-5aaf390c691a",
+          "_name": "Subdue"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bd2f6e16-7074-5a7f-9519-ced58f280310",
+          "_name": "Indomitable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5bcf1d26-581f-5510-a3be-2dcdd5a84246",
+          "_name": "Gamora"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "0861d97a-1c7d-5912-b67b-068f9990c03e",
+          "_name": "Athletic Conditioning"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "625ce78a-1caa-512b-929f-b40150803ead",
+          "_name": "Memories of Another Life"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "eae5c7a6-09e5-5ad9-9272-801b29c4218c",
+          "_name": "Cull the Weak"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c3959350-7aec-5020-be66-6ffc6201a859",
+          "_name": "Yotat the Destroyer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "da980a1a-4e73-58ef-9dda-551c0e96a097",
+          "_name": "Challenge Accepted"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "e175c2e3-37ed-5776-aa99-fa8d78d3b49f",
+          "_name": "\"I Will Destroy You!\""
+        }
+      ]
+    },
+    "Drax Nemesis": {
+      "label": "Drax Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "eae5c7a6-09e5-5ad9-9272-801b29c4218c",
+          "_name": "Cull the Weak"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c3959350-7aec-5020-be66-6ffc6201a859",
+          "_name": "Yotat the Destroyer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "da980a1a-4e73-58ef-9dda-551c0e96a097",
+          "_name": "Challenge Accepted"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "e175c2e3-37ed-5776-aa99-fa8d78d3b49f",
+          "_name": "\"I Will Destroy You!\""
+        }
+      ]
+    },
+    "Venom (Hero)": {
+      "label": "Venom (Hero)",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "159b710a-7668-5456-8b0c-c80a60b35b64",
+          "_name": "Venom"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4e4a929e-fb97-51ce-97e1-34f8d1e39158",
+          "_name": "Behind Enemy Lines"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "21564c1f-06ed-5574-8be2-2c7e2268122c",
+          "_name": "Grasping Tendrils"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "71f2d1c5-8828-534e-a93c-1fb5d7b8c26a",
+          "_name": "Locked and Loaded"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "3bb0c23e-86fc-5943-9872-fa3a20f70137",
+          "_name": "Run and Gun"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a0ec8b48-867d-5a2e-b3d6-40c9f4313a0c",
+          "_name": "Savage Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9188abfa-5464-53ff-a0dc-524ea56d5f0f",
+          "_name": "Project Rebirth 2.0"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5393950e-dc79-5eda-879d-7b0070cb4c0d",
+          "_name": "Multi-Gun"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "03865d87-b4c6-5ad1-aded-e477a6706c25",
+          "_name": "Spider-Sense"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b7508b89-76cb-577b-8466-21b7bee4aba5",
+          "_name": "Venom's Pistol"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2fec098e-82bd-57dd-a317-f19742aebc4a",
+          "_name": "Jack Flag"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "3d031b31-7c38-577e-9e9a-71687c76b97a",
+          "_name": "Scare Tactic"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "819cfc47-c4e0-5cb6-95ff-8c81acade3f6",
+          "_name": "Making an Entrance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "beba6d45-629f-55c9-94cf-3568c144eb6b",
+          "_name": "The Power of Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "cdd3ebfd-0ca3-5fe8-b1db-3b354a0e9214",
+          "_name": "Sonic Rifle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f27337ee-649c-52d2-85cf-a42f508d4f57",
+          "_name": "Star-Lord"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9a34026c-98c1-5e34-a4e2-92db54e1e57f",
+          "_name": "Resourceful"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2151c1e2-12d1-5c82-b690-ec0bf0abfdd0",
+          "_name": "Side Holster"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8f97ffb8-7cfe-589c-96f1-0899611dc484",
+          "_name": "Plasma Pistol"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5f7a3411-238d-5314-b45a-82c7ba6fe679",
+          "_name": "Struggle for Control"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b4179629-ae89-583e-a26e-fcd1f152e3da",
+          "_name": "Klyntar Frenzy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 4,
+          "databaseId": "7f2c2deb-dbac-595f-baff-5974ec577055",
+          "_name": "Enraged Symbiote"
+        }
+      ]
+    },
+    "Venom Nemesis": {
+      "label": "Venom Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b4179629-ae89-583e-a26e-fcd1f152e3da",
+          "_name": "Klyntar Frenzy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 4,
+          "databaseId": "7f2c2deb-dbac-595f-baff-5974ec577055",
+          "_name": "Enraged Symbiote"
+        }
+      ]
+    },
+    "Spectrum": {
+      "label": "Spectrum",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "32454da8-0327-5066-94c9-53ff4e4c7d04",
+          "_name": "Spectrum"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "e2062ce9-b6a2-5d0d-83ca-551b59f681b3",
+          "_name": "Gamma"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "c212b706-b758-51b4-a5f2-868594ed3cdc",
+          "_name": "Photon"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "b4744312-14b7-5008-97ee-b29c1a827b10",
+          "_name": "Pulsar"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b96681fb-9823-56ac-9e8d-f87fac1d56f1",
+          "_name": "Blue Marvel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "6398f05d-e11c-5821-bc6a-85bb5209ed53",
+          "_name": "Energy Duplication"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9a95ebfc-5ab8-5f48-95ad-baba4a340cd0",
+          "_name": "Gamma Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b0acd314-f175-51b1-a128-383c4e743447",
+          "_name": "Photon Speed"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "11e21bdb-5252-5dfe-aee1-ae8121e7e2cb",
+          "_name": "Pulsar Shield"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d9772c4d-da52-5e56-81d3-6388434aa94e",
+          "_name": "Speed of Light"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cceec6f1-0210-5ef2-be14-0a4c271b1259",
+          "_name": "Captain America"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a87733e5-bb30-527f-882b-cbda5ebf724b",
+          "_name": "Power Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ee868dd9-0715-5f8b-b20f-5090f796ca60",
+          "_name": "White Tiger"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c1400691-d132-50e7-9f6b-c0eac342657c",
+          "_name": "Kaluu"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f4ad7a00-c3ff-5ddb-8846-8b55f90ceb35",
+          "_name": "Mighty Avengers"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "afa6b6c2-f01b-578b-a0a0-de2fb0b4e431",
+          "_name": "Mass Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ca2b102a-e5ae-588f-8e77-b8c75751a88b",
+          "_name": "Moxie"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e6a81e96-1e57-5328-8c5a-392ad9e4fb72",
+          "_name": "Band Together"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "40b15d3f-7276-5090-bcb6-c653e3a483dd",
+          "_name": "Blade"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cd946d2e-d14d-5aca-beb5-b0b675c2bb48",
+          "_name": "Avengers Tower"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c8f6bf16-68c2-52f5-baf0-77270992a749",
+          "_name": "Ready to Rumble"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "681e4fcc-07d7-5a8b-912d-6812ef7db0e0",
+          "_name": "Loss of Control"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8c2275d7-0ef8-5174-a2d4-cef01bd8a4ca",
+          "_name": "Radioactive Man"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "83c162e9-f6ca-5f98-9d9a-49c72c34c4b0",
+          "_name": "Reactor Meltdown"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "545442f3-338e-59af-87d9-9fdbf3394aa5",
+          "_name": "Sap Power"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d9d3007f-b938-5219-aa59-3bbd82f4a751",
+          "_name": "Radioactive Blast"
+        }
+      ]
+    },
+    "Spectrum Nemesis": {
+      "label": "Spectrum Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8c2275d7-0ef8-5174-a2d4-cef01bd8a4ca",
+          "_name": "Radioactive Man"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "83c162e9-f6ca-5f98-9d9a-49c72c34c4b0",
+          "_name": "Reactor Meltdown"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "545442f3-338e-59af-87d9-9fdbf3394aa5",
+          "_name": "Sap Power"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d9d3007f-b938-5219-aa59-3bbd82f4a751",
+          "_name": "Radioactive Blast"
+        }
+      ]
+    },
+    "Adam Warlock": {
+      "label": "Adam Warlock",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "4a21ed94-493e-5c82-947b-dba6f0c90474",
+          "_name": "Adam Warlock"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2866d2c2-798e-5552-81d0-ad3fa0711335",
+          "_name": "Pip the Troll"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "20e77825-98c6-56c1-a83b-6240428cd609",
+          "_name": "Soul World"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "26f9ab97-f238-56e8-90e4-d65d9c41028e",
+          "_name": "Karmic Staff"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "82f17c0c-4158-506e-b4a5-d35793ac073a",
+          "_name": "Warlock's Cape"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c9b6e736-0ef7-5f20-ad58-f9ed62d116f3",
+          "_name": "Cosmic Ward"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bbad3f0a-5d38-5bc0-85b5-4518e548113d",
+          "_name": "Mystic Senses"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8a30aa37-97cd-5334-a8ec-db8aa80ed061",
+          "_name": "Karmic Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "84b0e0d0-9878-56fa-aba3-168bc23fd9fe",
+          "_name": "Cosmic Awareness"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "15db48df-41ad-5902-9a77-d531bb6b7af1",
+          "_name": "Quantum Magic"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "43ca1582-d6f7-510c-b13d-e6b9cc00d03f",
+          "_name": "Marvel Boy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c69dce4a-53cc-5f17-ae0d-dbfea3012d14",
+          "_name": "In-Betweener"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "891be642-0588-51b8-ae13-a3bf7b4b32cb",
+          "_name": "Magic Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "52ce4abf-f0bb-5144-ad68-4b27917d65e6",
+          "_name": "Uppercut"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3c8506e5-d29c-5c9c-81b8-ee0f47e91ea0",
+          "_name": "Combat Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "31ef60bd-3e8c-5b83-9470-7e110701e305",
+          "_name": "Audacity"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "87d3dc1a-340b-57ef-af81-0f98482903df",
+          "_name": "Quasar"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "171b536a-8772-549a-9b19-f210b4ea7d7d",
+          "_name": "Living Tribunal"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "96cb6425-1f73-5849-b6f3-69cdd718ab48",
+          "_name": "For Justice!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3013b665-4399-5747-8c5a-fc23f50fca60",
+          "_name": "Zone of Silence"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5d841847-94a8-5ff4-968a-fdbe5d4af9cd",
+          "_name": "Heroic Intuition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "be2d0bfa-f5e7-503c-8394-12af8b832b16",
+          "_name": "Determination"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b96ee560-0cf9-5fd2-a9c9-bfcce9c4559a",
+          "_name": "Major Victory"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5d711fa6-b894-5233-9208-4efadc847f70",
+          "_name": "Eternity"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9248c8d2-4969-5f97-86f6-037bb59eb162",
+          "_name": "Summoning Spell"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ced1d16c-ccfd-59e3-9547-911ff77521a7",
+          "_name": "Make the Call"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "717e6686-d007-5acb-a9a2-d2ac766f0930",
+          "_name": "Inspired"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9ed9f8d7-3ecd-582e-bca2-2a6545056e53",
+          "_name": "Innovation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "196654b4-7f73-5f84-9d02-89d19f7a04af",
+          "_name": "Charlie-27"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ad92c9e6-ba08-564f-a4f0-9d0282338825",
+          "_name": "The Gardener"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9f762a12-59b3-5e28-ba15-c855c0f60929",
+          "_name": "Shield Spell"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b90b259b-916b-5e38-b454-929125397d2c",
+          "_name": "Counter-Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b264b5f8-4830-5fc0-a35d-b011f005ece2",
+          "_name": "Armored Vest"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "02056a2c-9da0-5bc1-9a08-de52978d67f4",
+          "_name": "Preservation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d15533ae-ee6b-5586-afbf-3aaaff1ac2b4",
+          "_name": "Martinex"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5682de05-eeea-5fba-aca9-1331d487d9f2",
+          "_name": "Regeneration Cycle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f2d47005-70ef-5492-99ff-c7a28334dc0f",
+          "_name": "The Magus"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b5d5552f-ead9-5052-b705-c3b301ebbf57",
+          "_name": "Universal Church of Truth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "5cd81d40-b9a0-561e-819a-3a3787cd35f0",
+          "_name": "Zealot of Truth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a9b28bc8-d0c0-50c4-b10a-da88032da97c",
+          "_name": "Cosmic Inquisition"
+        }
+      ]
+    },
+    "Adam Warlock Nemesis": {
+      "label": "Adam Warlock Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f2d47005-70ef-5492-99ff-c7a28334dc0f",
+          "_name": "The Magus"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b5d5552f-ead9-5052-b705-c3b301ebbf57",
+          "_name": "Universal Church of Truth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "5cd81d40-b9a0-561e-819a-3a3787cd35f0",
+          "_name": "Zealot of Truth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a9b28bc8-d0c0-50c4-b10a-da88032da97c",
+          "_name": "Cosmic Inquisition"
+        }
+      ]
+    },
+    "Ebony Maw": {
+      "label": "Ebony Maw",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c749bb6f-8581-579c-961b-1cbc9a2db4e6",
+          "_name": "Ebony Maw"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "6ab439a9-14a2-5e28-a93d-6dccd6561208",
+          "_name": "Ebony Maw"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "0e728b9e-9bae-5239-b8ca-f81cf83f1a24",
+          "_name": "Ebony Maw"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "69899f00-2dc4-5092-82d6-48dd0d886088",
+          "_name": "Attack on Knowhere"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "88ab0e23-b62f-5de1-90e6-d104a0d0615e",
+          "_name": "The Power Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b93fe16d-06d9-5f5d-b0df-60a342f60977",
+          "_name": "Fireball"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7ff9d943-7e98-52b2-8b14-5ecf7445a890",
+          "_name": "Manipulation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ea27b66f-2977-5a5c-8b7c-b131be17be64",
+          "_name": "Pacification"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3b473d91-2f53-5a11-9432-f1f6bcefb5b7",
+          "_name": "Rubblestorm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4555188d-2442-5d15-9f32-66649a228e92",
+          "_name": "Agent of Thanos"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "c165f932-4b61-5cad-bb53-827e8a762f8c",
+          "_name": "Channeling Trance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "efd38941-da6e-544e-af42-99d52f4f2511",
+          "_name": "Abjuration"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db698697-9ca1-551c-b625-a6d5457fc6b0",
+          "_name": "Restrained"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "434183f4-f8a1-5b8d-858d-6ef848c08c96",
+          "_name": "Reactor Overload"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Ebony Maw"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "VAR",
+          "$SPELL_COND",
+          [
+            "POINTER",
+            [
+              "AND",
+              [
+                "EQUAL",
+                "$CARD_ITEM.sides.A.type",
+                "Environment"
+              ],
+              [
+                "IN_STRING",
+                "$CARD_ITEM.sides.A.traits",
+                "Spell"
+              ]
+            ]
+          ]
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$PLAYER_N",
+          "$PLAYER_ORDER",
+          [
+            "DISCARD_UNTIL",
+            "sharedEncounterDeck",
+            "{{$PLAYER_N}}Engaged",
+            "$SPELL_COND"
+          ]
+        ],
+        [
+          "MOVE_STACKS",
+          "sharedEncounterDiscard",
+          "sharedEncounterDeck",
+          [
+            "LENGTH",
+            "$GAME.groupById.sharedEncounterDiscard.stackIds"
+          ],
+          "shuffle"
+        ],
+        [
+          "COND",
+          [
+            "EQUAL",
+            "$GAME.mode",
+            "expert"
+          ],
+          [
+            "FOR_EACH_VAL",
+            "$PLAYER_N",
+            "$PLAYER_ORDER",
+            [
+              "DISCARD_UNTIL",
+              "sharedEncounterDeck",
+              "{{$PLAYER_N}}Engaged",
+              "$SPELL_COND"
+            ]
+          ]
+        ]
+      ]
+    },
+    "Black Order": {
+      "label": "Black Order",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43fdc637-c3e3-59e9-a3c9-2569d79cfd73",
+          "_name": "Black Dwarf"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af63dfc3-2186-5422-bb33-c5bd4dea6715",
+          "_name": "Supergiant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "51e0cc3b-0983-5f49-955e-4a8cb28d8c68",
+          "_name": "The Black Order"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a0d2ac73-d416-55a6-b952-0c359714389b",
+          "_name": "Blood to Spare"
+        }
+      ]
+    },
+    "Armies of Titan": {
+      "label": "Armies of Titan",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a4dfc65c-0604-5033-9630-64d0d051f5f2",
+          "_name": "Black Order Infantry"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "def0b699-9b56-55f6-8943-b4800037b0ea",
+          "_name": "Outrider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f359f1ed-bbed-5ae4-845d-2074d5b86fe3",
+          "_name": "Landing Craft"
+        }
+      ]
+    },
+    "Tower Defense": {
+      "label": "Tower Defense",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ee7c8594-b457-5fbc-88ae-74d677528351",
+          "_name": "Avengers Tower"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "93a05c64-11a2-54ae-9fa9-1c8c0bb41a6d",
+          "_name": "Focused Defense"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "e7d9f591-cc2d-507f-b99b-1908308e774d",
+          "_name": "Black Order Besieger"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a3aa9725-c073-5be8-981c-3886d39da7b3",
+          "_name": "Proxima's Spear"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6ee8bb8c-e08d-56bb-9bfb-2977a5ac732a",
+          "_name": "Corvus's Glaive"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "638279b9-c542-5699-9736-235a1ca47d29",
+          "_name": "Direct Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ced330c7-a0e2-596d-92f9-562eea966a0a",
+          "_name": "Proxima's Power"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "81d27673-1047-5e64-8055-e23526f8a1c6",
+          "_name": "Corvus's Cunning"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "021ca9d4-c0a7-5d87-be47-83dfdd00e665",
+          "_name": "Bound by Blood"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "e5670671-5558-5b7f-bd03-f4f44cef764a",
+          "_name": "Rain Fire"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "617fe3ab-3066-56a0-8447-6b2e681683da",
+          "_name": "City Under Attack"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "9bf90535-b03a-5e7a-ae12-57809485ba29",
+          "_name": "Proxima Midnight"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "724fa26a-c760-5f1f-b05c-98e7be66be37",
+          "_name": "Proxima Midnight"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "288322f1-899e-55b9-aed9-7e339c86c689",
+          "_name": "Proxima Midnight"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "aa07b34a-e156-5f72-8a00-81da2267ce2f",
+          "_name": "Corvus Glaive"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "0be95083-4c99-5295-89fe-1034f8e3f671",
+          "_name": "Corvus Glaive"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "84925d3f-031e-5715-8d9f-391c1531f301",
+          "_name": "Corvus Glaive"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "0da4e655-9a40-52bd-bb4e-78c2d97172bd",
+          "_name": "Under Siege"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "d4881afa-e54f-5e09-bafe-a64953708bd8",
+          "_name": "The Armies of Thanos"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Tower Defense"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          true
+        ],
+        [
+          "DEFINE",
+          "$NUM_VILLAINS",
+          2
+        ],
+        [
+          "LOG",
+          "Setup: Put Avengers Tower into play."
+        ],
+        [
+          "VAR",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "ee7c8594-b457-5fbc-88ae-74d677528351"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ],
+        [
+          "LOG",
+          "Setup: Every player gets a Black Order Besieger"
+        ],
+        [
+          "FOR_EACH_VAL",
+          "$PLAYER_N",
+          "$PLAYER_ORDER",
+          [
+            [
+              "DEFINE",
+              "$MINION_CARD",
+              [
+                "ONE_CARD",
+                "$CARD",
+                [
+                  "AND",
+                  [
+                    "EQUAL",
+                    "$CARD.databaseId",
+                    "e7d9f591-cc2d-507f-b99b-1908308e774d"
+                  ],
+                  [
+                    "EQUAL",
+                    "$CARD.groupId",
+                    "sharedEncounterDeck"
+                  ]
+                ]
+              ]
+            ],
+            [
+              "MOVE_CARD",
+              "$MINION_CARD.id",
+              "{{$PLAYER_N}}Engaged",
+              -1
+            ]
+          ]
+        ],
+        [
+          "VAR",
+          "$ATTACHMENT_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "93a05c64-11a2-54ae-9fa9-1c8c0bb41a6d"
+            ]
+          ]
+        ],
+        [
+          "VAR",
+          "$SCHEME_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "d4881afa-e54f-5e09-bafe-a64953708bd8"
+            ]
+          ]
+        ],
+        [
+          "ATTACH_CARD",
+          "$ATTACHMENT_CARD.id",
+          "$SCHEME_CARD.id"
+        ]
+      ]
+    },
+    "Thanos": {
+      "label": "Thanos",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "59756be8-6d3c-548c-b99f-f23edcc25662",
+          "_name": "Thanos"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "efde8743-b06e-53f9-a41c-4dfeb6574d81",
+          "_name": "Thanos"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "00c3ef3d-65d8-53b4-9e0c-3038fc77ff1c",
+          "_name": "Thanos"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "07391816-2cb2-5f41-a98a-1e4038608b3d",
+          "_name": "The Infinity Stones"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "97a8f9d5-6ecb-53b4-aff1-0a622db18b75",
+          "_name": "Balance the Scales"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "94517591-d5cc-5a31-ae45-d5a76d5a5e8b",
+          "_name": "Sanctuary"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7e69cf22-00f5-599b-a385-140995d6d69c",
+          "_name": "Thanos's Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c5201238-a608-5088-84df-5495575970a5",
+          "_name": "Thanos's Helmet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "09610dec-e30b-5c3c-a1d4-a2a9e306b23f",
+          "_name": "Master of the Stones"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fdab7e43-aa6f-5fac-adba-0e3a73e73672",
+          "_name": "Avatar of Death"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a350e584-cef8-551a-bc24-f62af3c65003",
+          "_name": "Deviant Syndrome"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "10716979-bcfa-5233-b10a-5f3198624575",
+          "_name": "\"I Am Inevitable\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0ba7e603-26e2-53dd-ab7b-8737f76bca07",
+          "_name": "The Mad Titan"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3c6a8710-27aa-5eca-acdd-9997af0e0662",
+          "_name": "The Titan's Throne"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Thanos"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Thanos"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Children of Thanos": {
+      "label": "Children of Thanos",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9b75ea59-41fc-5d35-b765-095d2c3f5ab0",
+          "_name": "Corvus Glaive"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6d81c708-24b6-5bec-8ae8-a98ddc0c5250",
+          "_name": "Proxima Midnight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "686e22c2-2399-54b9-8d1b-cc97315c04ca",
+          "_name": "Ebony Maw"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9e150713-af28-5b7c-a45d-37c912e03ced",
+          "_name": "Tribute"
+        }
+      ]
+    },
+    "Infinity Gauntlet": {
+      "label": "Infinity Gauntlet",
+      "cards": [
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "588ac077-fcb5-5bc1-bfa0-03b43756fa0e",
+          "_name": "Infinity Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "3277a37a-ede4-5100-9ed9-7ca638cf1d20",
+          "_name": "Mind Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "5c64001d-a0f9-536c-a8e7-65f5cb055f3c",
+          "_name": "Power Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "05c46b1b-6c55-50a9-90a7-1f251654393f",
+          "_name": "Reality Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "85d41b03-1e25-57f2-b6e7-e02047b60a64",
+          "_name": "Soul Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "ff79201c-d6d2-5e54-8e23-c90f6c623234",
+          "_name": "Space Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "83878bd5-4a4b-5b15-a58c-be916684852b",
+          "_name": "Time Stone"
+        }
+      ]
+    },
+    "Hela": {
+      "label": "Hela",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3d40201c-8914-5f81-ae6e-d089bf1bab3f",
+          "_name": "Hela"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "e6fee0f1-8863-570e-9f21-4e86c9c86f06",
+          "_name": "Hela"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "51ccedeb-9d16-56f2-834c-52a670d9fa51",
+          "_name": "Odin's Torment"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4841bd29-be3d-5f60-adba-d7f2d83b1f81",
+          "_name": "Odin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9bb3473f-d0b6-594a-946d-e726e486fd47",
+          "_name": "Gnipahellir"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "51118e72-cec1-5291-a95c-891b73b78a94",
+          "_name": "Gjallerbru"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "33c005a5-7071-525a-8256-8e70ddcb0137",
+          "_name": "Hall of Nastrond"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d5b21e6e-09b2-5c50-9c05-f43a0e62c46f",
+          "_name": "Garm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1eec51c1-e453-5094-9a66-f67f0b30cdfc",
+          "_name": "Skurge"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "05d07215-56e2-57ea-b016-fac8b37b33a6",
+          "_name": "Nidhogg"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4f628b72-dc67-5a3a-8225-b8de1be4dbf0",
+          "_name": "Nightsword"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f52560fc-0aa9-5f12-919b-b21b14ce0af6",
+          "_name": "Hela's Crown"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e625928c-88d2-512e-a58f-0e50dbd7e6f3",
+          "_name": "Hela's Cloak"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "397f1b46-a475-5135-9c1d-b34bf7c82522",
+          "_name": "Hela's Domain"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "519dc584-4068-5b4b-a835-742bf4f9225f",
+          "_name": "The Queen of Hel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2089313f-ab2e-50b3-a60f-344fd363960a",
+          "_name": "The Wastes of Niffleheim"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Hela"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Legions of Hel": {
+      "label": "Legions of Hel",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "452ddecd-5f59-5e08-8d25-22b70fac345c",
+          "_name": "Draugr"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "327e4ee3-2652-5ceb-99f8-85afb2f77dae",
+          "_name": "Fallen Warrior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fd15629d-e6a3-5282-bab7-ed4d11c11a8d",
+          "_name": "No Place for the Living"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8688abf2-2a15-5880-af03-d4d351b649e1",
+          "_name": "Legions of Hel"
+        }
+      ]
+    },
+    "Frost Giants": {
+      "label": "Frost Giants",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "216a46d2-9143-591e-aa58-c95ad960bb4a",
+          "_name": "Laufey"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a8acb875-5a8b-560e-9bb8-5b34f93ce397",
+          "_name": "Frost Giant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "71283519-5467-588d-a99c-261e35b376a9",
+          "_name": "Frozen"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5e6c19a8-d11f-5bd8-a76b-0eac941f6720",
+          "_name": "Unnatural Storm"
+        }
+      ]
+    },
+    "Loki": {
+      "label": "Loki",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7f3f3cd1-5d7e-5b20-a4ff-5600a70bd0a0",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "6fd5c23c-d751-50e6-b721-e6b0c88cd540",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "b3016557-48e8-501e-83ba-6b59c596cd1a",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "2d12c9cb-34e4-5d18-88bd-1e032a4ebd48",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "fd44d0b2-781f-5133-abaa-ce21dff8e332",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "fe2ec2ed-df8e-5ace-8954-86ef43a43698",
+          "_name": "All Hail King Loki"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e45c6322-51f9-5f20-8618-e7ccdaca1ba2",
+          "_name": "Casket of Ancient Winters"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "feb3f068-cf67-5a82-a525-1ba5a84b0280",
+          "_name": "War in Asgard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9433bc7c-073c-505f-b650-5d937a0d110b",
+          "_name": "Madness on Midgard"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "577bc961-b3b7-5b31-ae15-bc16b0f0001e",
+          "_name": "Open the Bifrost"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7681d2dd-d60b-5e44-b66a-5174d4132b2c",
+          "_name": "Loki's Staff"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2dee4827-88d2-5495-ae04-706894a6355d",
+          "_name": "Loki's Crown"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "87e68727-7a65-58a2-82aa-4bb7a77dae67",
+          "_name": "Loki's Cape"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f45cac8-a7c3-5785-9196-de372e0bddc6",
+          "_name": "Master of Illusions"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "629a451f-4d9e-5255-9a37-5d51bc99896b",
+          "_name": "Devious Sorcery"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0f90fda2-d391-5d4c-bcfa-61b9b687a9cd",
+          "_name": "Infinite Mischief"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "0fe5505a-961f-5ac6-83d5-ce7d70f73ae7",
+          "_name": "The Trickster"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Loki"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Loki"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Enchantress": {
+      "label": "Enchantress",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7c3482be-5047-5094-b5ea-7d1c0a264bfe",
+          "_name": "Enchantress"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "88a5ff03-20c7-5200-b676-565b2d096b95",
+          "_name": "Beguiled"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c984f13b-4ef1-5426-a51e-bc92042e96e3",
+          "_name": "Seduced"
+        }
+      ]
+    },
+    "Campaign (The Mad Titan's Shadow)": {
+      "label": "Campaign (The Mad Titan's Shadow)",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "77f57360-aef2-53e3-ab8f-f831acf4b447",
+          "_name": "Secure the Landing Pad"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b74e3d58-f275-5819-b238-44d4252acde8",
+          "_name": "Security Breach"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "08b6dce9-c7a7-5a38-8fdd-8091212ae293",
+          "_name": "Save the Shawarma Place"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 4,
+          "databaseId": "f16685bc-c471-5324-9f8a-5e5f7be99012",
+          "_name": "Shawarma"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "55273264-ca6b-5e7b-b9e4-58a662947c10",
+          "_name": "Hack Sanctuary's Computer"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 4,
+          "databaseId": "11210114-10fc-5c22-b5bf-1ad9139a677e",
+          "_name": "System Shock"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b78e4cb5-39de-559a-9695-e45ef17ae93d",
+          "_name": "Find the Norn Stones"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 4,
+          "databaseId": "c08ed245-bf65-57ec-b8f3-fcfa2edf263c",
+          "_name": "Norn Stone"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "3af43c49-2ca9-5178-879a-e4c8f1b26222",
+          "_name": "Summoned Back"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "3ffbfefc-518c-53b2-b464-20cbc0d47960",
+          "_name": "Open the Dungeons"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6f54b4cf-c6a4-5774-92c5-ecd2fef9cf57",
+          "_name": "Lady Sif"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "71ea75ce-5f0e-579d-a0a2-a7a9a73b841e",
+          "_name": "Fandral"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "692e166e-7f18-5d4d-9f3d-334535df072b",
+          "_name": "Hogun"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "4f4f062c-0028-54c0-abe3-ca50cc669e1b",
+          "_name": "Volstagg"
+        }
+      ]
+    },
+    "Nebula (Hero)": {
+      "label": "Nebula (Hero)",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "aecd14bd-7bf3-5c22-a035-772e03fc55bf",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "66d93436-ce93-5d4e-b70e-14324a663c3b",
+          "_name": "Gamora"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "96c6f99e-555e-5d6d-9add-9dc9db678be3",
+          "_name": "Nebula's Ship"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d6ba99cf-c524-5cad-b4e5-0388195711d0",
+          "_name": "Cutthroat Ambition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "79ed1f9f-c568-559b-8ba8-3c18d6dcc76d",
+          "_name": "Evasive Maneuvering"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7c2a78b4-66dd-54ee-99a9-3e962d27d65c",
+          "_name": "Unyielding Persistence"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3233c4be-cdaa-5583-8efc-168ec7892857",
+          "_name": "Weapons Master"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ce0377bc-fbe1-51d4-9fcc-fb0caf9fe03d",
+          "_name": "Wide Stance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "7b3e31c4-f82e-56c8-982a-1d678c96ce3a",
+          "_name": "Combat Ready"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d69c87ee-071d-566c-a5b0-47644cb62b83",
+          "_name": "Lethal Intent"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "388f452a-7eef-54fc-97b9-da5abb2e8a7e",
+          "_name": "Eros"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e299859b-e286-5f92-8238-ea446bbd873a",
+          "_name": "Wraith"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7b16b84d-4d8a-51e6-877b-7500d25b67b0",
+          "_name": "Venom"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "1dfda25f-0970-5113-b2ed-fadff03af209",
+          "_name": "Justice Served"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e31428de-e5bc-598c-a127-ee51cdbe842d",
+          "_name": "One Way or Another"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "be2d0bfa-f5e7-503c-8394-12af8b832b16",
+          "_name": "Determination"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "beba6d45-629f-55c9-94cf-3568c144eb6b",
+          "_name": "The Power of Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "94d743cc-c2d5-5a49-acd8-8d598a1541b1",
+          "_name": "Brains Over Brawn"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5d841847-94a8-5ff4-968a-fdbe5d4af9cd",
+          "_name": "Heroic Intuition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "036a02f6-89d6-566c-b50c-8e29b76864e0",
+          "_name": "Cosmo"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "62f627c7-a5b6-50ce-b9c0-7fadd1aa222e",
+          "_name": "Knowhere"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9960bbcc-89ea-5736-8cb0-10b140eab6bf",
+          "_name": "Daughters of Thanos"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e68b02a5-adf5-54b6-b343-1b1a29fb4752",
+          "_name": "First Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e5439a28-188b-58ac-823a-d7186b14351b",
+          "_name": "Inferiority Complex"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5e644c46-fb25-53cb-afbf-6539e2da5406",
+          "_name": "Gamora"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f1070231-5489-52cf-9784-8c517838ea49",
+          "_name": "Self-Preservation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "605c704e-d1ce-55f9-8c84-f601c11fe6b7",
+          "_name": "Lethal Weapon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "2554e7c3-7788-5cad-b540-484da132765c",
+          "_name": "Old Rivals"
+        }
+      ]
+    },
+    "Nebula Nemesis": {
+      "label": "Nebula Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5e644c46-fb25-53cb-afbf-6539e2da5406",
+          "_name": "Gamora"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f1070231-5489-52cf-9784-8c517838ea49",
+          "_name": "Self-Preservation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "605c704e-d1ce-55f9-8c84-f601c11fe6b7",
+          "_name": "Lethal Weapon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "2554e7c3-7788-5cad-b540-484da132765c",
+          "_name": "Old Rivals"
+        }
+      ]
+    },
+    "War Machine": {
+      "label": "War Machine",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "5c7a58ea-6b79-5e7e-82ca-fbb8e7acce01",
+          "_name": "War Machine"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f34d5899-2ed8-5325-975c-b3cd77c56233",
+          "_name": "Iron Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ed9b7eea-f068-5c58-a834-ff3de352054a",
+          "_name": "Munitions Bunker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "765296ed-0d78-5fe3-9875-2c54fdacc38a",
+          "_name": "Upgraded Chassis"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "80ad04b9-3d0e-53dd-bb82-05e57069a7f5",
+          "_name": "Gauntlet Gun"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e0faf525-81ea-5275-8f5d-b91b64e9a29d",
+          "_name": "Missile Launcher"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "08191c82-ea8b-5201-ab69-b1c977d589d3",
+          "_name": "Shoulder Cannon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "67d7c714-a941-5f65-87c1-20245ae85966",
+          "_name": "Repulsor Beam"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ae3c6cc2-7943-5821-a36f-2a1eef5e93a1",
+          "_name": "Targeted Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9b472634-55dc-5340-8794-f306090a2cfc",
+          "_name": "Scorched Earth"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c1edd495-3d4b-52f4-ae7c-e39cda399e99",
+          "_name": "Full Auto"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0a7ada46-5505-5381-ba7c-5a22de98c7d1",
+          "_name": "Black Panther"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9c57e581-0160-5d12-b431-ab9087603e87",
+          "_name": "Captain Marvel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3924a9bc-008a-5807-9388-59086ab0a255",
+          "_name": "Falcon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f75bc378-cf92-59db-bec8-daa12cd04ce2",
+          "_name": "Goliath"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "236bbb7b-de51-5a0f-b151-71bf4bbca400",
+          "_name": "Command Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "38ba2f0b-3911-5b12-b48c-17c19ad827c9",
+          "_name": "Sneak Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a9b73972-52b8-54e2-b228-c71da8694aa6",
+          "_name": "Save the Day"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8d2cca27-2d3e-5df7-b91a-2d1bdd3bb245",
+          "_name": "Go Down Swinging"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ced1d16c-ccfd-59e3-9547-911ff77521a7",
+          "_name": "Make the Call"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9ed9f8d7-3ecd-582e-bca2-2a6545056e53",
+          "_name": "Innovation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7f03b038-38a6-5d4b-bb8e-10df13fe58b5",
+          "_name": "Mockingbird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c2c11795-326e-57c3-9712-0e6736d8ac03",
+          "_name": "Quincarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "f1ffc9bf-8efc-5b9f-8199-c22ddea4ebc7",
+          "_name": "Two Against the World"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c14c4381-7412-589e-b384-b1679cf00ca6",
+          "_name": "Equipment Malfunction"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "e6897454-1b25-5665-93bd-cd07a0faede7",
+          "_name": "Living Laser"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "874bcf7c-a027-593c-b25f-77c5aad2b640",
+          "_name": "Deadly Light Show"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "557c125e-3d38-5c9c-930f-e03daa7b0385",
+          "_name": "Laser Strike"
+        }
+      ]
+    },
+    "War Machine Nemesis": {
+      "label": "War Machine Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "e6897454-1b25-5665-93bd-cd07a0faede7",
+          "_name": "Living Laser"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "874bcf7c-a027-593c-b25f-77c5aad2b640",
+          "_name": "Deadly Light Show"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "557c125e-3d38-5c9c-930f-e03daa7b0385",
+          "_name": "Laser Strike"
+        }
+      ]
+    },
+    "The Hood": {
+      "label": "The Hood",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "5c2647ca-1b72-5b2d-84c1-a7237b43ff1a",
+          "_name": "The Hood"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "ca6ebe18-37a2-511a-87ff-56225291f16a",
+          "_name": "The Hood"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "2cc21da8-18e9-5d8f-a7da-e86df323b84c",
+          "_name": "The Hood"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2acda1ff-0d5c-504a-b495-195002b85a9e",
+          "_name": "Establish Dominance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "63fff313-c8bb-5625-ad92-94455bb2b2ca",
+          "_name": "The Hood's Mantle"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f0d12fb4-12e6-599e-be2b-8fdfc4ac19f1",
+          "_name": "The Hood's Pistol"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eabd82bb-c00e-5fdd-8f85-f3107c8d0689",
+          "_name": "Madame Masque"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0d1fc9f6-b5d9-5c97-959a-302ad555b7b5",
+          "_name": "Unbridled Ambition"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "676f3dd1-9374-5d05-9c09-b48bd8161b63",
+          "_name": "Field Recruitment"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "a4d590af-e599-53c1-a193-0dd444c201e9",
+          "_name": "Upper Hand"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "71f89a2f-c58c-5bab-9155-c61316281deb",
+          "_name": "Making Connections"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "72228e27-2095-5d05-aeab-4124ea020421",
+          "_name": "Promised Prosperity"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "eda49ee6-b721-5202-a661-353f607149c9",
+          "_name": "Crime State"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Beasty Boys": {
+      "label": "Beasty Boys",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fb576616-aeaf-5134-bba6-0641f43ae333",
+          "_name": "Beast Mode"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d3950a78-60b0-569a-b2b9-8cc8ff7aa2bd",
+          "_name": "Griffin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3dd0f928-6166-53f4-8951-c8f23dcb44ff",
+          "_name": "Mandrill"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0dc5184a-4695-515d-be5a-fba192d01d3a",
+          "_name": "Double Trouble"
+        }
+      ]
+    },
+    "Brothers Grimm": {
+      "label": "Brothers Grimm",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a949a6ba-2c80-549e-b55e-1b24f196b44f",
+          "_name": "Brothers Grimm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "767ac192-9209-5b25-8578-dc5dc7be5682",
+          "_name": "Blackbird Pellets"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c831d46e-4fc8-5d59-ba36-295e445333e6",
+          "_name": "Corrosive Egg Bomb"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6aa7274c-07e3-542b-8110-417f9759466a",
+          "_name": "Paralytic Stardust"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e05b80b1-0dac-54a0-b823-0f9c83f1dbd2",
+          "_name": "Unbreakable Thread"
+        }
+      ]
+    },
+    "Crossfire's Crew": {
+      "label": "Crossfire's Crew",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "922f747e-0bda-5e1f-844b-7382cbd3e5bd",
+          "_name": "Out for Blood"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c8fa5160-33c1-58ae-87f5-d6df022cfff4",
+          "_name": "Controller"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dbdec393-19cd-589f-8568-95d0e369f689",
+          "_name": "Corruptor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d4a71c48-77d8-55fc-849f-cf466a3c1231",
+          "_name": "Crossfire"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ed9f59f9-c774-57c2-bf80-5a246693db84",
+          "_name": "Mister Fear"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e091f07a-161c-5ffd-8549-2837c028b982",
+          "_name": "Caught in the Crossfire"
+        }
+      ]
+    },
+    "Expert II": {
+      "label": "Expert II",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ee46d1b1-f695-5bfb-8749-dca33784100c",
+          "_name": "Cruel Intentions"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7d5a4630-52e3-5938-be88-658c9e542488",
+          "_name": "Ruination"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b04f9c63-b52e-5efc-8dc7-1c99067751a7",
+          "_name": "Seek and Destroy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "618e824f-b8d3-5496-b83b-15d8e7b4dc76",
+          "_name": "Slug it Out"
+        }
+      ]
+    },
+    "Mister Hyde": {
+      "label": "Mister Hyde",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "98f91ff4-3426-559f-a6e2-42afd9ec7532",
+          "_name": "Self-Experimentation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0d319386-8046-5c55-ac60-f1f39edc27a1",
+          "_name": "Calvin Zabo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "367df7fb-8bf4-590f-96d6-e62c9aeda2f7",
+          "_name": "Mister Hyde"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b780ffb8-f8a1-5dac-b91b-ef26b6a3bdb6",
+          "_name": "Hyde Formula"
+        }
+      ]
+    },
+    "Ransacked Armory": {
+      "label": "Ransacked Armory",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fc06fb74-61a8-586a-a729-da8076765f5e",
+          "_name": "Flamethrower"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2852b8da-293d-551b-b438-c9b04947aeaa",
+          "_name": "Holoshield Generator"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d2b38e11-1d23-5d04-8ed9-03a8ec7ae9d2",
+          "_name": "Jetpack"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a1de43cb-0b55-5b43-beb2-3fb7aa3d3156",
+          "_name": "Tech Gauntlets"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8fb8f34d-78d4-549c-a00f-a91dcf38b193",
+          "_name": "Armored Guard"
+        }
+      ]
+    },
+    "Sinister Syndicate": {
+      "label": "Sinister Syndicate",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "90fffe1a-31f2-53bd-9b8b-547e4c5f14ff",
+          "_name": "Crime Pays"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bce628f2-3993-5dda-b608-adcc654fc86d",
+          "_name": "Beetle"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f0b668ae-4b2b-56be-adac-d3fb7d107790",
+          "_name": "Boomerang"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "93a3cd61-4800-59c8-9a67-85877c69f744",
+          "_name": "Shocker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9397e488-cdda-50cb-9463-e27b097b2c76",
+          "_name": "Speed Demon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0d6aedc9-f4b9-540c-a50e-b22efb12f673",
+          "_name": "White Rabbit"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af6802e6-9853-54f9-afe2-5d76e88b1f70",
+          "_name": "Sinister Onslaught"
+        }
+      ]
+    },
+    "Standard II": {
+      "label": "Standard II",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "42dca407-6e81-54b1-8812-b244d9128d71",
+          "_name": "Formidable Foe"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "bcbb0013-527c-5b09-b216-c31b50abd396",
+          "_name": "Dark Dealings"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c95f319e-11cc-5e45-b306-b3457b90fb0c",
+          "_name": "Mob Mentality"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "531e83a7-85f5-5d49-854a-5766b706482b",
+          "_name": "Overwhelming Force"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "469b291f-931e-5546-a5e0-9b67f931cb7a",
+          "_name": "Shadow of the Past"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "30296901-01b0-5553-b4a2-4b9c2d836b49",
+          "_name": "Total Annihilation"
+        }
+      ]
+    },
+    "State of Emergency": {
+      "label": "State of Emergency",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "842224a8-0886-5b87-b2a6-55f7f91d4cde",
+          "_name": "Feisty Heist"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "53fca05f-2296-5e29-a4fc-e71b06ff34a3",
+          "_name": "Disaster at the Docks"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6e23c029-fe7a-5993-836b-ef211dc6ff71",
+          "_name": "Offshore Inferno"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d3f4da61-9507-5e9a-9c0a-e3c84d155058",
+          "_name": "Hot Pursuit"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "de79383c-f9c0-5e1b-aca8-cfb830955d85",
+          "_name": "Citywide Crisis"
+        }
+      ]
+    },
+    "Streets of Mayhem": {
+      "label": "Streets of Mayhem",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "552784ca-feae-5b7e-89d5-6e9b9f4cfe9c",
+          "_name": "Back-Alley Enclave"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "98ff579e-c16f-5abe-a300-03ce46f16b40",
+          "_name": "Secret Lair"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "de89cd60-2a54-5771-9b36-6b9153fa061f",
+          "_name": "Sewer Tunnels"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0b884420-25cd-5a09-be97-292e110ad5ff",
+          "_name": "Warehouse District"
+        }
+      ]
+    },
+    "Valkyrie": {
+      "label": "Valkyrie",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "dea1dcd1-11ad-51ad-8635-490a986d8672",
+          "_name": "Valkyrie"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a2c91b59-0554-59ef-8990-a5500c996824",
+          "_name": "Death-Glow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c7109a6c-aeeb-5fe9-8c4f-26b43c3ad018",
+          "_name": "Anabelle Riggs"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "796aff23-575c-5359-9ebf-e2089d7c6fbe",
+          "_name": "Valhalla"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "735b77a1-14ab-5b85-91b6-2cc850130d15",
+          "_name": "Valkyrie's Spear"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "685ec320-9e50-5ee2-873c-a1c59233e824",
+          "_name": "Dragonfang"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "15f9be53-52a8-5482-8c30-e590b7b366fd",
+          "_name": "Aragorn"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "8b83522e-8f92-5ced-9f5a-8e0d5615962d",
+          "_name": "Flight of the Valkyrior"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "70f6fe17-bd35-5cce-902d-6513ff23b269",
+          "_name": "Visit Valhalla"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "729f16be-e931-5cd9-960e-9ce0da91227d",
+          "_name": "Chooser of the Slain"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "6c745178-9d50-5ecb-bc44-f05d3d0d319b",
+          "_name": "Shieldmaiden"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "acfb7823-9241-572d-9595-a05dd2902c69",
+          "_name": "\"Have at Thee!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ab1bbcfc-bf1f-5ced-a498-e61b4bc9c18a",
+          "_name": "Thor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1bd97114-92ca-5108-8bf5-d90ab26e7411",
+          "_name": "Throg"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e213147a-281a-5ce9-a50b-2298219f53af",
+          "_name": "Angela"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2d2e09aa-0d98-5cfa-94b9-c06e6bf854aa",
+          "_name": "Hall of Heroes"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3c8506e5-d29c-5c9c-81b8-ee0f47e91ea0",
+          "_name": "Combat Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "86a8afb5-cd8d-5bf2-871a-5bd22be3ca8d",
+          "_name": "Quick Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "0de364c4-4417-540b-8a78-d47283790e32",
+          "_name": "Smash the Problem"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a8b4a1b5-5b5d-5bce-b725-cdab8230b776",
+          "_name": "The Best Defense..."
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "31ef60bd-3e8c-5b83-9470-7e110701e305",
+          "_name": "Audacity"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "466d7afe-8445-5e53-8e94-458fbb8617e4",
+          "_name": "The Bifrost"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "61fb31de-6006-5bb0-b4e3-1b47113eadb6",
+          "_name": "Godlike Stamina"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a95e8710-d931-568e-83f1-73a4a80a71e5",
+          "_name": "Trouble in Otherworld"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7c3482be-5047-5094-b5ea-7d1c0a264bfe",
+          "_name": "Enchantress"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b07258cf-1715-5479-937f-2ab61b5f8afb",
+          "_name": "Powerful Enchantments"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "88a5ff03-20c7-5200-b676-565b2d096b95",
+          "_name": "Beguiled"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "c984f13b-4ef1-5426-a51e-bc92042e96e3",
+          "_name": "Seduced"
+        }
+      ]
+    },
+    "Valkyrie Nemesis": {
+      "label": "Valkyrie Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7c3482be-5047-5094-b5ea-7d1c0a264bfe",
+          "_name": "Enchantress"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b07258cf-1715-5479-937f-2ab61b5f8afb",
+          "_name": "Powerful Enchantments"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "88a5ff03-20c7-5200-b676-565b2d096b95",
+          "_name": "Beguiled"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "c984f13b-4ef1-5426-a51e-bc92042e96e3",
+          "_name": "Seduced"
+        }
+      ]
+    },
+    "Vision": {
+      "label": "Vision",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "de3560ca-17d2-54f4-9427-2d0d171ca5d1",
+          "_name": "Vision"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "7d6563e4-1f0d-5abe-865e-d3971dc5ed61",
+          "_name": "Intangible"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a4bf50a1-a011-5ef6-af95-4171cca5ed49",
+          "_name": "Vivian"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1d2afc2c-1968-5efb-be4d-93d2f703bcc3",
+          "_name": "616 Hickory Branch Lane"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "524f2845-7099-5822-8edf-71f42f1718e8",
+          "_name": "Solar Gem"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "826c6c89-18b4-5904-99fb-12ac7dc65be6",
+          "_name": "Vision's Cape"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5b4bed86-e6e4-5fa5-b80a-52085747b111",
+          "_name": "Density Control"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "714e9bc5-22a8-5551-85d5-5427e2fb8331",
+          "_name": "Solar Beam"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2c456f89-3160-5d36-973e-0d4bdde2158b",
+          "_name": "Superdense Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "75fa9e06-19c3-5c67-b202-a8a0c251e9aa",
+          "_name": "Just Passing Through"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "78447a05-655d-5cbb-a874-f55b81e8340a",
+          "_name": "Phase Disruption"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb80213e-580f-5108-82fd-b54d6cff3adf",
+          "_name": "Mass Increase"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "86a53ec1-d1c8-53cf-a0ec-cec89c9ae377",
+          "_name": "Jocasta"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "320a6bef-f826-5da8-99c0-616dc12703b6",
+          "_name": "Protector"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1d142415-bdb1-5221-90c3-fabad9b937ce",
+          "_name": "Victor Mancha"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "34633e6f-bafa-5bc1-b404-eda2397f30c2",
+          "_name": "Flow Like Water"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bd2f6e16-7074-5a7f-9519-ced58f280310",
+          "_name": "Indomitable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "4eac08cf-8652-5219-a43a-66d136d43e1a",
+          "_name": "Defiance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b50e5539-2e49-5631-94d5-b9fef0d6b3fb",
+          "_name": "Side Step"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "a793780e-eb17-530b-8723-c7c295f0fe3e",
+          "_name": "Get Behind Me!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "02056a2c-9da0-5bc1-9a08-de52978d67f4",
+          "_name": "Preservation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "87e3729b-440f-54aa-9cb3-4920aafd47db",
+          "_name": "Machine Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a30f67c3-21df-5b31-86a3-9e2244fd5170",
+          "_name": "Avengers Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b356c50b-1d23-5c4a-a4f0-1011da7c464f",
+          "_name": "Reboot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "46cdfa8e-2b80-5a49-b1fe-3b1a806e49ff",
+          "_name": "Corrupted Programming"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7f4341cd-5fc3-555c-8a94-e3a7304d195a",
+          "_name": "Ultron"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13331cd6-ecd4-5d6a-bfe3-00f156d6d871",
+          "_name": "Ultron Unleashed"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8dc89688-080f-55ec-a557-c469bc9b4705",
+          "_name": "Ultron Drones"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "cccd4ecb-70e2-5629-8f4f-87ec8c42340f",
+          "_name": "Relentless Android"
+        }
+      ]
+    },
+    "Vision Nemesis": {
+      "label": "Vision Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7f4341cd-5fc3-555c-8a94-e3a7304d195a",
+          "_name": "Ultron"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13331cd6-ecd4-5d6a-bfe3-00f156d6d871",
+          "_name": "Ultron Unleashed"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8dc89688-080f-55ec-a557-c469bc9b4705",
+          "_name": "Ultron Drones"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "cccd4ecb-70e2-5629-8f4f-87ec8c42340f",
+          "_name": "Relentless Android"
+        }
+      ]
+    },
+    "Ghost-Spider": {
+      "label": "Ghost-Spider",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "ef672556-9ca8-5abf-91a8-ba2cc9fbbcb2",
+          "_name": "Ghost-Spider"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "362b7635-5152-58cd-997b-cec63ff628fe",
+          "_name": "Ghost Kick"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb3bb9ff-8b07-5e3f-b778-9475d89b6708",
+          "_name": "Parental Guidance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "821a9675-210a-5519-b40f-5a3e3a684e6c",
+          "_name": "Phantom Flip"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5a79d1f8-a40a-5c3e-97eb-b2a5bac4f199",
+          "_name": "Pirouette and Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "0f9f3edd-0cf2-5c4a-b6e3-67e4e1d563b7",
+          "_name": "Web Binding"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "495c0200-1899-5c8c-9ba2-5ac57b94a6cd",
+          "_name": "George Stacy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b24ea552-d1f2-525a-8d29-19fa266ab8fb",
+          "_name": "Ticket to the Multiverse"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "6453929e-342b-5ddb-8759-589d400c1f22",
+          "_name": "Web-Bracelet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "fbc51124-2710-5c13-9bc7-329553657220",
+          "_name": "Silk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "696c2bab-503d-590e-997d-d6be7616c71c",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9e451266-aa9b-571b-99c6-9687fef7bb0f",
+          "_name": "Spider-UK"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "13835646-14cf-55dd-ae2b-5259e3fdbe79",
+          "_name": "Bait and Switch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ddfab7c6-b93e-53e0-aa41-8129ce1134a5",
+          "_name": "Jump Flip"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "860babe1-1500-59e1-863e-3c0aac1c2a57",
+          "_name": "Return the Favor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ea267e78-8020-5d9a-a89e-300b59f29829",
+          "_name": "What Doesn't Kill Me"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "004ad22a-4cb7-5406-ad0c-16143ecd5e02",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6c5fa4cd-a49a-5f94-a053-17e9db99dcab",
+          "_name": "Across the Spider-Verse"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ec55a840-b56f-5897-a6a2-e120b2f6144a",
+          "_name": "Young Love"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b6ae0aa7-9cf1-5d7b-a449-7d3850b2152b",
+          "_name": "Web of Life and Destiny"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c334d85f-bbf6-505d-96c5-8a7e9e561bdc",
+          "_name": "Plan B"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "470e2437-1f6d-5485-bdb2-4d20a947a3f7",
+          "_name": "Worried Father"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9017f11e-add0-5696-b210-cb536efcdf7b",
+          "_name": "Regenerative Research"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "922ea99b-fbec-504d-b2c9-19b2bb563188",
+          "_name": "The Lizard"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bc83222a-5ad9-5e91-a7cb-448a46f6b704",
+          "_name": "Experimental Injection"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ac52b622-4230-5536-ab64-43646850760c",
+          "_name": "In Cold Blood"
+        }
+      ]
+    },
+    "Ghost-Spider Nemesis": {
+      "label": "Ghost-Spider Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9017f11e-add0-5696-b210-cb536efcdf7b",
+          "_name": "Regenerative Research"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "922ea99b-fbec-504d-b2c9-19b2bb563188",
+          "_name": "The Lizard"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bc83222a-5ad9-5e91-a7cb-448a46f6b704",
+          "_name": "Experimental Injection"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ac52b622-4230-5536-ab64-43646850760c",
+          "_name": "In Cold Blood"
+        }
+      ]
+    },
+    "Spider-Man (Miles Morales)": {
+      "label": "Spider-Man (Miles Morales)",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "3392ba83-1e54-599f-82f1-14b2ffca0616",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "abd7b780-3c08-5ed2-a429-26b5be108f86",
+          "_name": "Arachnobatics"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2b63f2b0-42ea-5da3-a492-a18483b84b38",
+          "_name": "Double Life"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "f0079635-55c9-5fd4-b697-66af1ccc0607",
+          "_name": "Swing In"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "1621536c-e2db-5715-ab4a-17b4ade145d7",
+          "_name": "Web-Shot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "aa103089-b8a9-5cc7-8e7c-1ee28e4351c8",
+          "_name": "Ganke Lee"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "36bcac83-26c9-5558-b2de-26c886cdfc24",
+          "_name": "Jefferson Davis"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cb416a00-f1e9-531d-ace6-eaa5cd3f1e4a",
+          "_name": "Power Within"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6a0f7f20-1a53-5f2f-9471-82c63dd08a6c",
+          "_name": "Defense Mechanism"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "73027f2b-119d-5f3e-9049-0fb9aff7f0ce",
+          "_name": "Web-Shooter"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "46d7a69f-8e17-5523-a838-14faf16ef298",
+          "_name": "Monica Chang"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c82afc91-6314-5128-a958-14118ab6eb1d",
+          "_name": "Spider-Woman"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6df2781b-28d8-572d-8e15-14848df401ff",
+          "_name": "Homeland Intervention"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "39e2e5e4-1929-55a9-a5cf-497418a20542",
+          "_name": "Global Logistics"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d62d704d-a651-5ff6-88f4-70365b0ab8a5",
+          "_name": "Field Agent"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "560cbe53-74a5-5338-bab9-5dbdb8cbfe02",
+          "_name": "Surveillance Team"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a380c6bb-2192-515b-a493-9d8d1b62d46f",
+          "_name": "Agent 13"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "514758c1-cf08-5902-a95d-bcaaedc5fb15",
+          "_name": "Dum Dum Dugan"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5c6c2193-83da-572d-a3c5-3f0577d61fee",
+          "_name": "Ghost-Spider"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9786ec3e-bae6-57ea-bf75-0110178f18a2",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ec55a840-b56f-5897-a6a2-e120b2f6144a",
+          "_name": "Young Love"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b7a2d1a3-88aa-5722-bfd9-a4cba9076544",
+          "_name": "Government Liaison"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0d01ecec-34c8-58c9-8b27-966f7d9c1497",
+          "_name": "Sky-Destroyer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "03ae3c93-2b59-51b6-a866-70494e8d8c58",
+          "_name": "Keeping Secrets"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "19884b4d-93ea-562b-b795-2d3e1de29c04",
+          "_name": "Tracking Prey"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "025cc3d9-c45a-5f3e-b5a5-aaf8657c783a",
+          "_name": "Prowler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7d8ee4b2-4cef-5bd3-b0eb-2d6a15a3d5bd",
+          "_name": "Razor Claws"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "18b80aa8-78d6-5617-ae47-33d2bec4479b",
+          "_name": "Slice and Dice"
+        }
+      ]
+    },
+    "Spider-Man Nemesis (Miles Morales)": {
+      "label": "Spider-Man Nemesis (Miles Morales)",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "19884b4d-93ea-562b-b795-2d3e1de29c04",
+          "_name": "Tracking Prey"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "025cc3d9-c45a-5f3e-b5a5-aaf8657c783a",
+          "_name": "Prowler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7d8ee4b2-4cef-5bd3-b0eb-2d6a15a3d5bd",
+          "_name": "Razor Claws"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "18b80aa8-78d6-5617-ae47-33d2bec4479b",
+          "_name": "Slice and Dice"
+        }
+      ]
+    },
+    "Sandman": {
+      "label": "Sandman",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "75be8c10-2424-57d2-9d85-76e3c97602ab",
+          "_name": "Sandman"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "e4a14868-3c49-5beb-9bec-1a8f0f37733d",
+          "_name": "Sandman"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f6ccb187-d9e4-588c-9e3c-b1f0842849b7",
+          "_name": "Sandman"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "ab889d74-d8c1-574e-a2b4-1bc344b95827",
+          "_name": "Hapless Pedestrians"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ff2be8cf-0927-5d6e-ad19-ec40735b8ecb",
+          "_name": "City Streets"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f4a61a69-d72c-510e-9bad-de1508548339",
+          "_name": "Sand Form"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "e9c8ebdb-34aa-57f6-92c4-a4bd514cf6a0",
+          "_name": "Sand Clone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a5480789-2c85-5d55-8403-5eb56faa484a",
+          "_name": "Dirt Trap"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fee44554-80f1-5909-8f4c-ef5e0a0383d0",
+          "_name": "Tidal Sands"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bfaa2a98-3246-5ee2-9f61-f6ff69b91087",
+          "_name": "Sandslide"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3d680a0b-ef4d-5951-b567-b097eaf3ae4f",
+          "_name": "Sand Storm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8894d168-172c-55d9-b482-07c9b78e64c2",
+          "_name": "Sand Smash"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Sandman"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Sandman"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Venom (Scenario)": {
+      "label": "Venom (Scenario)",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "50ff16be-7866-5247-8cbd-d045bd12f879",
+          "_name": "Venom"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "78f58342-57b8-5c0e-8ef1-358c89f1dfe9",
+          "_name": "Venom"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "22079c1a-8abb-5149-8160-a8b7600c9a7f",
+          "_name": "Venom"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "c248eae4-a9ce-5e2a-8265-ea2e420d9e2b",
+          "_name": "\"Leave Us Alone!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d2f94480-244a-568c-bcf7-d7cf7815f572",
+          "_name": "Bell Tower"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2f6d2d1d-ae78-5425-90cf-4376286793c9",
+          "_name": "\"Now We're Angry!\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "85e998b0-ee8a-5485-875b-cdec4c5b87c4",
+          "_name": "Guard the Bell Tower"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8576e974-1cdf-50ec-b46c-f0999798edd7",
+          "_name": "Lashing Out"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "251b6aba-e24a-597f-85a6-4c9063fd418b",
+          "_name": "Tooth and Nail"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fd771d87-39ed-537c-a0ed-3c7d52ded62a",
+          "_name": "Biting Retort"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "61abb5aa-d541-5ab6-988f-7095bbfb27c6",
+          "_name": "For Whom the Bell Tolls"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Venom"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Venom"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Mysterio": {
+      "label": "Mysterio",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "096e202f-8bb0-54e8-a5f3-2f7417dde75c",
+          "_name": "Mysterio"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c314c2fc-8638-5115-8531-b8a693ae7f50",
+          "_name": "Mysterio"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "5fbd2ac1-565a-5083-b7cb-6cb660e6ffb8",
+          "_name": "Mysterio"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "2b7f477c-b2ea-5e73-aecd-13f0eae8a63d",
+          "_name": "Maze of Mirrors"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "646df971-d93b-51b2-a6e2-aa17cdbc3f4a",
+          "_name": "Edge of Reality"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0448701b-1e2e-5a8d-9d21-aa7899386bc2",
+          "_name": "Humongous Hallucination"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f149336b-cf38-5968-aaf3-d00e9e63cce0",
+          "_name": "Masterful Mirage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "857a0373-269b-5335-8646-6419a6b51b7f",
+          "_name": "Shifting Apparition"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0d845e72-9075-59ce-80c6-a65c1987ab24",
+          "_name": "Déjà Vu"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "e08bf75a-854f-5120-9a23-9d1912dd1735",
+          "_name": "Fearmonger"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Mysterio"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Mysterio"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "The Sinister Six": {
+      "label": "The Sinister Six",
+      "cards": [
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "c94efbc6-6cba-54d9-ab88-ee1209503fb9",
+          "_name": "Sinister Synchronization"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "2ecd8909-415f-5c2d-8ce8-da1ec73339e2",
+          "_name": "Sinister Beatdown"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "de9f3efd-51ca-51e0-a354-9241b482c1b8",
+          "_name": "Light at the End"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3dbfa094-5647-52ca-b5b2-343417f83d1a",
+          "_name": "Heightened Morale"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4d15dae7-a121-5fb0-b6f8-e650fac0621a",
+          "_name": "Taunting Presence"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8f3e9930-b5d2-5907-8f82-080ec317c99f",
+          "_name": "Team Leader"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "302e2f5e-acc2-5a17-9ab5-abe1bb18be88",
+          "_name": "Take One for the Team"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "91735eeb-8b42-5bbc-bba4-bd51f4c884fe",
+          "_name": "Brute Force Barricade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9749fd27-4721-55ce-ba86-14bc21fd65ac",
+          "_name": "Frequent Flyers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d4cebca5-dc07-5c78-a2b3-6a5564a824d6",
+          "_name": "High Fashion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "25115a20-9858-5527-a74c-7dd14c23cb96",
+          "_name": "Robotic Enhancements"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "caa7462f-48bf-5334-a802-a347908eeda0",
+          "_name": "Partnership of Pain"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "e8b7716a-11a8-54dd-8a50-24e50ceeb955",
+          "_name": "Surprise!"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c0014750-9750-54be-8af1-7ffa6e40ce35",
+          "_name": "Doctor Octopus"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "69ea44f1-a0bd-5be7-a04e-93b94b952319",
+          "_name": "Electro"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d9372116-0beb-5629-8db6-478f73b78bee",
+          "_name": "Hobgoblin"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "35f41776-c23b-5696-8aaa-af9a88ea9141",
+          "_name": "Kraven the Hunter"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "691f2f3f-a5d6-5555-b49a-141b782e3488",
+          "_name": "Scorpion"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c15668d3-24f0-582c-9bfc-7dc7fbbf5174",
+          "_name": "Vulture"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "The Sinister Six"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Venom Goblin": {
+      "label": "Venom Goblin",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "55b14f73-4a38-5ea4-99f6-5bbace8dd020",
+          "_name": "Venom Goblin"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d077643d-dcd6-5030-bfa2-b1f04ed99f21",
+          "_name": "Venom Goblin"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "cdfd77bd-6aab-5ad3-989a-c258fdcb3200",
+          "_name": "Venom Goblin"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "31ed1ef0-e195-5860-af65-a71eafdf0d8d",
+          "_name": "Skies Over New York"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "dc04b321-ad76-5ea2-bc09-f8a727d9d16f",
+          "_name": "Lower Manhattan"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "d480bbae-ebc8-5b2b-abcb-c52786f8f7d1",
+          "_name": "Midtown Manhattan"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "6a13a80e-8505-5c76-b54e-9e0882d5f9e0",
+          "_name": "Upper Manhattan"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1a690aa9-61c9-51b2-a398-5e072516a7a1",
+          "_name": "We Are One"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c9c0c398-0a29-5311-8e03-9cc4343a1913",
+          "_name": "Symbiotic Berserker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ff8a8565-f086-5bb8-b452-1d6463da2222",
+          "_name": "Symbiotic Monstrosity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "770067a6-c073-5f93-9918-854323e08271",
+          "_name": "Symbiotic Thrall"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a78d7d4e-8fd1-56a5-9396-4a85592fcb28",
+          "_name": "Festering Mass"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "97ab0d3a-ae22-542c-beed-c67f5e2a590f",
+          "_name": "Joy Ride"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "88c0f7d5-2367-571d-9ea2-7c8e80819b28",
+          "_name": "Spreading Panic"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Venom Goblin"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Venom Goblin"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "City in Chaos": {
+      "label": "City in Chaos",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b80e3792-2ef8-58a6-80a1-0f0d61f8c46b",
+          "_name": "Panic in the Streets"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ca41bcf8-6591-5c4f-bfe2-b83c42a8ce67",
+          "_name": "Rhino"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c64835f1-90d4-5778-966e-ca13d4e34f0a",
+          "_name": "Calling in Favors"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "321d6d55-64e6-525b-8c6c-bbd412289141",
+          "_name": "Now or Never"
+        }
+      ]
+    },
+    "Down to Earth": {
+      "label": "Down to Earth",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "828cf12e-1c0d-5852-a5f1-771b9abd54e1",
+          "_name": "Common Criminal"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ffe988b0-aa91-57f6-9df1-ae00b07a7711",
+          "_name": "Friends and Family"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6410f474-9ee6-50ea-a6ad-f90b62e3b8f0",
+          "_name": "Volunteer Work"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "735b0512-9087-51fd-9c36-3fe6ca1528dd",
+          "_name": "\"Threat or Menace?\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f1ac5331-3bf0-5530-81ec-c2a35d7ab93b",
+          "_name": "Loose Ends"
+        }
+      ]
+    },
+    "Goblin Gear": {
+      "label": "Goblin Gear",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c003ce1a-fac6-5b18-91f6-8a22470115f4",
+          "_name": "Advanced Glider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f8e0ee0b-39a0-5f0b-987b-75e42e83ef48",
+          "_name": "Concussive Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43c53db2-83bc-54a4-b22d-881e7a131647",
+          "_name": "Incendiary Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "78930bca-6d1d-5caf-adee-c22c276783ec",
+          "_name": "Smoke Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f7ce8a15-a768-5f19-980b-116f0554dcc6",
+          "_name": "Limitless Supply"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f6fd8aef-d5e9-5dff-93b8-5d454df55b8a",
+          "_name": "Remote Navigation"
+        }
+      ]
+    },
+    "Guerrilla Tactics": {
+      "label": "Guerrilla Tactics",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "86cb308f-f8a2-59d8-8ccd-45a8f1c7e1c6",
+          "_name": "Life-Size Decoy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a10be59f-70aa-551e-88a6-964f4d9fbb8a",
+          "_name": "Coordinated Effort"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0850115d-10ae-5a2d-a6e5-411457676b9d",
+          "_name": "Hidden in Shadow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "757e5fce-9acc-5a92-8e98-b0d0b88ecc4b",
+          "_name": "Teamwork Makes the Dream Work"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "94db4813-0d4e-54e4-b8da-7af62c76d08a",
+          "_name": "From Every Direction"
+        }
+      ]
+    },
+    "Osborn Tech": {
+      "label": "Osborn Tech",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "51f14e32-bdf2-5322-bbdb-789f85269b5e",
+          "_name": "Arm Cannon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c264ff18-3ef6-50d5-8f34-830d821577c8",
+          "_name": "Ionic Boots"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f6187dec-a2d3-5393-87d8-9482ecd5e0b1",
+          "_name": "Kinetic Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0051331-331f-5f77-ac79-0b9443faa33e",
+          "_name": "Neocarbon Scales"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "00721b9c-b6fe-57db-84d1-231419a04b91",
+          "_name": "Spiked Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "90fa83ec-5c01-5e97-a488-a3a027040c01",
+          "_name": "Tracking Display"
+        }
+      ]
+    },
+    "Personal Nightmare": {
+      "label": "Personal Nightmare",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ecfdffcd-0ebd-57ba-a673-46d03cf005e6",
+          "_name": "Induced Panic"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "008b3a59-fd80-5861-b52b-225ecff1746b",
+          "_name": "Evil Doppelgänger"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3cea8feb-c28e-5f69-9cbb-318e494b4493",
+          "_name": "Fool's Paradise"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7a7d346f-420c-59a9-892a-8edc48d6ee60",
+          "_name": "Weakness from Within"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "cdd99c14-e7d2-5ebb-a2de-bf150443ec76",
+          "_name": "Deepest Fears"
+        }
+      ]
+    },
+    "Sinister Assault": {
+      "label": "Sinister Assault",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "81bbbfea-0786-5423-932b-5c9c9e372f38",
+          "_name": "Doctor Octopus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "599a866c-4ce2-5e1c-8517-7c37782c8c8a",
+          "_name": "Electro"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c0d6d34e-3eb2-5e3a-ad7a-4156fe5c6e3d",
+          "_name": "Hobgoblin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8ba6fbf4-20f2-59d8-bf6f-dad47ce78189",
+          "_name": "Kraven the Hunter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "61a05a04-3cd9-5fbf-b682-463f9a512ccd",
+          "_name": "Scorpion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f984a95-4266-5b4d-8cd0-6a982c3c6418",
+          "_name": "Vulture"
+        }
+      ]
+    },
+    "Symbiotic Strength": {
+      "label": "Symbiotic Strength",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c78c238e-360b-5824-bc52-21b8dd732224",
+          "_name": "Improvised Weapons"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0577f48c-1344-5eaa-b0cb-df91750f37c1",
+          "_name": "Violent Tendencies"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b7e0cf48-cf86-5487-93e1-dd08e86b5933",
+          "_name": "Webbed Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "7f2c2deb-dbac-595f-baff-5974ec577055",
+          "_name": "Enraged Symbiote"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1bd73c69-8057-5675-b12a-78c2babac149",
+          "_name": "Swinging Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41f2143b-6d8d-53a0-84dd-9251e52f6114",
+          "_name": "Unstable Sentience"
+        }
+      ]
+    },
+    "Whispers of Paranoia": {
+      "label": "Whispers of Paranoia",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "10583ae5-966b-56ef-b63e-b38d08271ff2",
+          "_name": "Delusion of Collusion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d1c4c962-8606-50d5-a7bf-c72b38f6d433",
+          "_name": "Manipulated Mind"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eaa606f6-11e9-5570-9c9b-d49656b7d795",
+          "_name": "Old Grudge"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "382df7d8-b1c8-5884-9fc2-ceadb79a36cc",
+          "_name": "Analysis Paralysis"
+        }
+      ]
+    },
+    "Campaign - Bad Publicity": {
+      "label": "Campaign - Bad Publicity",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "7b3b88c0-e105-57f8-bbb1-bdde3858ea5b",
+          "_name": "Public Outcry"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "eb1642fb-e699-596a-876f-0a0ac2ab8806",
+          "_name": "Smear Campaign"
+        }
+      ]
+    },
+    "Campaign - Community Service": {
+      "label": "Campaign - Community Service",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "26b3c18a-9d69-5076-ab6e-b27a6efe42eb",
+          "_name": "Back Alley Burglary"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "784cde2c-3281-56e7-a212-85e55a058c41",
+          "_name": "Cat in a Tree"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "968aff74-916c-51d3-b4e4-7b76efba6f5f",
+          "_name": "Henchman Heist"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b4946da9-b9e1-5ae3-9514-248904f0331d",
+          "_name": "Off the Rails"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "9cd28935-89f3-5c90-af22-f89b2b73461b",
+          "_name": "Rubble Rescue"
+        }
+      ]
+    },
+    "Campaign - Snitches Get Stitches": {
+      "label": "Campaign - Snitches Get Stitches",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "ce3760aa-03e3-512b-9291-84726cd3bb90",
+          "_name": "Snitches Get Stitches"
+        }
+      ]
+    },
+    "Campaign - S.H.I.E.L.D. Tech": {
+      "label": "Campaign - S.H.I.E.L.D. Tech",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "2ba0c7cb-4041-5d2c-b482-2457a9081e14",
+          "_name": "Compact Darts"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b06cd176-94e4-5005-9e5a-17e3c2ee410e",
+          "_name": "Impact-Dampening Suit"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "a27563db-674a-5898-a1c5-689025d70b0f",
+          "_name": "Laser Goggles"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6936134c-d278-50d2-ae75-e0e854cb0b78",
+          "_name": "Propulsion Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "ba1e6a9a-5e71-5e3d-8c56-df41df9174ad",
+          "_name": "Retinal Display"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "21d99f59-4074-50e3-b9ff-777e194f3afb",
+          "_name": "Shock Knuckles"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "0c616bab-ad91-5549-a28a-91ba46a23a17",
+          "_name": "Wave Bracers"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "f9cab955-0155-5e8b-8ced-054594f80ef5",
+          "_name": "Wrist Navigator"
+        }
+      ]
+    },
+    "Nova": {
+      "label": "Nova",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "97e4f3a2-b3dd-539d-aa91-f29790964b25",
+          "_name": "Nova"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "79706eec-5b74-5dea-9592-b0537990f8a2",
+          "_name": "Ms. Marvel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "57971522-37b2-5030-aa01-66b9d187c7e2",
+          "_name": "Forcefield Projection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "059e0dab-41cf-5da7-b0df-693ceb25c91c",
+          "_name": "Lightspeed Flight"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d35f2c39-9da5-5300-a746-54451c4d8014",
+          "_name": "Pot Shot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4cb8c23c-e6e8-5738-a131-7dfd720cbe2f",
+          "_name": "Unleash Nova Force"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4b85ea79-40ce-5221-8236-e5f3f91742dc",
+          "_name": "Connection to the Worldmind"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b70da4ca-71b7-5b57-a206-22f1f78b3ff8",
+          "_name": "Jesse Alexander"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "612c075f-5511-588a-aaf3-777c661fdf49",
+          "_name": "Supernova Helmet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b6a6797e-71ce-50c1-873f-9600b941937d",
+          "_name": "The Locust"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b7b48c3f-99e2-5e32-82b5-3f6f7b955781",
+          "_name": "Chase Them Down"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "41530dc2-75b6-5dbc-82f3-4baab55eb3bc",
+          "_name": "Pitchback"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "cc55b079-9b93-5f1f-a25e-08a5654e47bf",
+          "_name": "No Quarter"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "12be90e3-6247-5198-9182-60a4fc000edf",
+          "_name": "One by One"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "540d2668-c509-585a-b0bd-214ac30642f7",
+          "_name": "Fluid Motion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d33e5d21-de9c-5dd0-818d-3ef89c828368",
+          "_name": "Honed Technique"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "42e4ba03-4f9f-5047-ae0e-13bfa22b5b2b",
+          "_name": "Moon Girl"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e60412ad-4b7a-5d51-87c6-c1c9c724279b",
+          "_name": "Everyday Hero"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "59f7898a-c3b9-5beb-9fda-f7c8ff08eebb",
+          "_name": "Champions Mobile Bunker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7ea95a07-96bb-504a-8438-5c5b69467003",
+          "_name": "Weight of the World"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ffdf414b-4c29-5bcc-b159-d25513884637",
+          "_name": "\"Bring the War!\""
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d2d20a3a-ee49-56de-a10c-4892bcbadd9f",
+          "_name": "Warbringer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "06e31034-789a-536f-ae99-a0d8e172cc79",
+          "_name": "War Delivery"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b0619561-7b86-59db-9fc5-89f0e428aaf7",
+          "_name": "\"The War's Been Brought\""
+        }
+      ]
+    },
+    "Nova Nemesis": {
+      "label": "Nova Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ffdf414b-4c29-5bcc-b159-d25513884637",
+          "_name": "\"Bring the War!\""
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d2d20a3a-ee49-56de-a10c-4892bcbadd9f",
+          "_name": "Warbringer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "06e31034-789a-536f-ae99-a0d8e172cc79",
+          "_name": "War Delivery"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b0619561-7b86-59db-9fc5-89f0e428aaf7",
+          "_name": "\"The War's Been Brought\""
+        }
+      ]
+    },
+    "Armadillo": {
+      "label": "Armadillo",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d7f0508f-61bc-5a3f-bebb-13eecd0cb2c9",
+          "_name": "Armored Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8f00adbd-faf3-5613-89dd-033d5d790d11",
+          "_name": "Armadillo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "57314247-0301-5c48-9fae-3aa630eaebf7",
+          "_name": "Rollin', Rollin'"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "19008715-8fac-5d2a-a849-6d040492efa3",
+          "_name": "Tough and Tumble"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c9e4967a-c42c-59c5-9aff-ecd38ad761c9",
+          "_name": "Tough It Out"
+        }
+      ]
+    },
+    "Ironheart": {
+      "label": "Ironheart",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "602e603f-7e92-57f6-9b9f-7b7f8a18de9b",
+          "_name": "Ironheart"
+        },
+        {
+          "loadGroupId": "playerNOutOfPlay",
+          "quantity": 1,
+          "databaseId": "0006bfd8-06a5-5928-8d17-1b4971407dbc",
+          "_name": "Ironheart"
+        },
+        {
+          "loadGroupId": "playerNOutOfPlay",
+          "quantity": 1,
+          "databaseId": "23858611-0f2c-5e28-8aae-cc9258600557",
+          "_name": "Ironheart"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "354a4401-150b-50b7-b52d-e637d151f226",
+          "_name": "Brawn"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "dacb88f6-1d42-5578-98b7-47ef90aca745",
+          "_name": "Fly Over"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "251c77b2-0a59-5380-bb53-4fa31067f3b8",
+          "_name": "Photon Beam"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9b33653e-046e-540d-93ae-0fd38d2214fd",
+          "_name": "New and Improved"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "39f3e850-4650-53db-83f6-4496fa06b457",
+          "_name": "Sector Scan"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b9b79c9f-84d6-56ec-9f2c-146be62050c2",
+          "_name": "Stroke of Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c64d184f-1272-5ea4-92cb-ef681380ae27",
+          "_name": "Ronnie Williams"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "276cb44a-d207-5e8d-9538-c62e4f5d6e83",
+          "_name": "Tony Stark A.I."
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "80af967f-a05a-5c79-92d3-4acaa7614eda",
+          "_name": "Photon Blasters"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "37eef69a-71b9-58f6-96a6-ae58e74d249c",
+          "_name": "Propulsion Jets"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6b74fd43-8137-57f4-bad3-6da82d154ed3",
+          "_name": "Cloud 9"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "92e8521b-0c09-5b6b-9e93-7c89185960a6",
+          "_name": "Falcon"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "98207355-0b32-5d1c-83d3-ce91f3123439",
+          "_name": "Patriot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "68261604-b77b-5aa3-8820-90c3190682b9",
+          "_name": "Go All Out"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2821978a-ef83-528f-ba41-c8efc3ea4c08",
+          "_name": "Push Ahead"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "72b0e95d-6146-56bb-8b9b-829d0cea0f26",
+          "_name": "Morale Boost"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e21b0cef-3cd5-5deb-be15-dce485d3067a",
+          "_name": "R&D Facility"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "04fe3e79-279a-5d4b-93f4-bf6fa562e825",
+          "_name": "The Power of Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a380c6bb-2192-515b-a493-9d8d1b62d46f",
+          "_name": "Agent 13"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0a7e590e-bf5a-5cf8-961e-e7f444d02c34",
+          "_name": "Snowguard"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f7ae3674-2997-52c5-903a-6c8306aaaa25",
+          "_name": "Vivian"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8ae0ff46-c155-5243-b332-80e99a126ff3",
+          "_name": "\"Go for Champions!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "19049ed0-ec36-575c-a1a2-054d542e4def",
+          "_name": "Helicarrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a7057b28-4dd3-512d-a6a2-662093367a81",
+          "_name": "Ingenuity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "37882d1b-5f85-5f87-8a26-1f8c72681030",
+          "_name": "A Minor Setback"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6656ec87-7505-5be7-90e0-b06aa5a9bb20",
+          "_name": "Rule by Force"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8a627fe6-38a6-5d19-bb99-f7e97e5903dd",
+          "_name": "Lucia von Bardas"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f6fd3422-28bd-57a5-b0dd-c501f7a19b48",
+          "_name": "Cyborg Tech"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "7d81af68-3b3a-5716-b795-347853eab319",
+          "_name": "Political Retribution"
+        }
+      ]
+    },
+    "Ironheart Nemesis": {
+      "label": "Ironheart Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6656ec87-7505-5be7-90e0-b06aa5a9bb20",
+          "_name": "Rule by Force"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8a627fe6-38a6-5d19-bb99-f7e97e5903dd",
+          "_name": "Lucia von Bardas"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f6fd3422-28bd-57a5-b0dd-c501f7a19b48",
+          "_name": "Cyborg Tech"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "7d81af68-3b3a-5716-b795-347853eab319",
+          "_name": "Political Retribution"
+        }
+      ]
+    },
+    "Zzzax": {
+      "label": "Zzzax",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a6c20cc6-615c-5c57-b3e1-c449c4f58803",
+          "_name": "Feedback Loop"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "11e326bb-b2e4-521f-94fc-a510788b09fa",
+          "_name": "Zzzax"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6f054849-9985-5872-90d6-6f5f6457381c",
+          "_name": "Haywire"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0606adae-858e-51cc-a162-77824f8d2e19",
+          "_name": "Air Static"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1e6ad491-cbb5-5c8a-85d6-50318790aa21",
+          "_name": "Zzzap!"
+        }
+      ]
+    },
+    "Spider-Ham": {
+      "label": "Spider-Ham",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "dc15c87a-dbed-5869-9139-dedeee62de4a",
+          "_name": "Spider-Ham"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cd41223b-3009-5bd3-9290-3be359511af5",
+          "_name": "Captain Americat"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "33e732ee-b8de-5c5e-8634-a3bf57a5c771",
+          "_name": "Ham It Up"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0858ad55-eb7e-53c4-a509-3cd043ffbd33",
+          "_name": "Hogwashed"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c332e602-a970-583c-8631-df8c0d29b57b",
+          "_name": "\"I Don't Think So!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e48065b0-f7ff-5edd-9141-23b610ea1db7",
+          "_name": "Petulant Pig"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e42b449d-2e45-542d-a733-17b0c1dc21c5",
+          "_name": "Swinging Web Pig"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ac049148-ce26-58ff-9c97-d4ed389424fd",
+          "_name": "The Daily Beagle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "be9cf74c-12f2-546f-9b66-96a10a66315e",
+          "_name": "Cartoon Physics"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "279b945b-3b4d-5332-be91-b8aabed2e16f",
+          "_name": "Huge Wooden Hammer"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0b0cf464-e7c3-5c73-b1cb-9ab5f55ee39c",
+          "_name": "Organic Webbing"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "96967d54-4f14-5aa6-afdc-cd2fdaadb10f",
+          "_name": "Lady Spider"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "57526978-6645-5fd5-ae4e-59baf35285ad",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2031e243-bde1-5192-9397-d7a2962ada0f",
+          "_name": "Even the Odds"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "26edcf96-51be-5844-b02e-06b60c4d91ce",
+          "_name": "Great Responsibility"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "819cfc47-c4e0-5cb6-95ff-8c81acade3f6",
+          "_name": "Making an Entrance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e31428de-e5bc-598c-a127-ee51cdbe842d",
+          "_name": "One Way or Another"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "daee8602-44a3-5571-a756-45bb452a56be",
+          "_name": "Followed"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f59664a1-2166-50d2-8c41-580ebb5dae4b",
+          "_name": "Overwatch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "adf6f3bf-d70a-5782-be2e-4c2ff62c17dc",
+          "_name": "Scarlet Spider"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "eea5e782-54c3-5ccd-84bf-42a2f201cb9b",
+          "_name": "SP\/\/dr"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5733abf2-e5a1-5218-8c51-7e4c2f3142de",
+          "_name": "Team-Building Exercise"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b6ae0aa7-9cf1-5d7b-a449-7d3850b2152b",
+          "_name": "Web of Life and Destiny"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6cf69f7a-ac07-5920-8656-72597be47093",
+          "_name": "\"I Really Want a Hot Dog!\""
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b04bf7b8-b4fe-5fad-a023-d1ef1123c083",
+          "_name": "Nefarious Trap"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7cae1c5f-d081-58b3-abd8-0bf859a013d9",
+          "_name": "The Green Gobbler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "399db354-07cc-5183-9c86-ed2a3d101efb",
+          "_name": "Gobbler Glider"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "b5c44837-aff4-5b73-837c-a60f4f9f4992",
+          "_name": "\"Feast on This!\""
+        }
+      ]
+    },
+    "Spider-Ham Nemesis": {
+      "label": "Spider-Ham Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b04bf7b8-b4fe-5fad-a023-d1ef1123c083",
+          "_name": "Nefarious Trap"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7cae1c5f-d081-58b3-abd8-0bf859a013d9",
+          "_name": "The Green Gobbler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "399db354-07cc-5183-9c86-ed2a3d101efb",
+          "_name": "Gobbler Glider"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "b5c44837-aff4-5b73-837c-a60f4f9f4992",
+          "_name": "\"Feast on This!\""
+        }
+      ]
+    },
+    "The Inheritors": {
+      "label": "The Inheritors",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6820b2f3-311b-5327-99c8-e96b5e18ec6f",
+          "_name": "Hunting the Spider-Totems"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "22dd384e-0a7c-5685-82aa-807171424116",
+          "_name": "Bora"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "08a827d9-865e-56e9-a722-68110169fbec",
+          "_name": "Brix"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "16983953-537a-5960-8003-e34c658501d4",
+          "_name": "Daemos"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "92dbb3db-5871-5987-ab87-161d62bf65b1",
+          "_name": "Jennix"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c49a9214-2eff-585a-85df-2eeb5a15445b",
+          "_name": "Karn"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "00a50c3d-bad0-5ed8-9a0a-7238fbc56d9c",
+          "_name": "Morlun"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fbf4db75-658d-5911-99e2-daf11e9e788d",
+          "_name": "Solus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7bb03ea6-9d9d-5b6a-b5cd-02b7d84de3df",
+          "_name": "Verna"
+        }
+      ]
+    },
+    "SP\/\/dr": {
+      "label": "SP\/\/dr",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "94028a84-59b8-52ca-bdb0-5228cbd23318",
+          "_name": "SP\/\/dr Suit"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "36943f94-3731-5bed-9b56-59fbdd69f968",
+          "_name": "Peni Parker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c4914116-6303-569d-965d-61049b91b1eb",
+          "_name": "VEN#m"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8ba898b8-afa5-588a-8f95-e34d6766da15",
+          "_name": "All Systems Go!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "40725a02-7887-53c9-a0d1-0488204bc736",
+          "_name": "Rapid Deployment"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2e425ff8-6df9-53c2-9c3a-98fe52d261c9",
+          "_name": "Web-Trap"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9ccfa07c-7499-59f6-b278-6a42fd77b9c6",
+          "_name": "Aunt May & Uncle Ben"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cc9d4133-1f49-5fb1-8ca8-d85e517d6856",
+          "_name": "Ejection Protocol"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "240e6a44-c858-5b55-b39f-ddf12468d6a8",
+          "_name": "SP\/\/dr Command"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4e4b27c7-969a-5961-94b7-9f6a34f40ecb",
+          "_name": "Host Spider"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e64083d7-dab6-5e69-b6c5-217ba89a032e",
+          "_name": "Psychic Link"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "167549e4-bb16-5219-ab93-ff0b9801bc7f",
+          "_name": "Speed-Metal Alloy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ef0bbde2-da4f-5287-9e18-27c0d2ac7231",
+          "_name": "Web-Fluid Compressor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "26177b02-2d7f-5324-a02b-f293851ef9ad",
+          "_name": "Daredevil"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d0ee86c9-3cbe-51e7-9740-997ae39e99cb",
+          "_name": "Spider-Man Noir"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "26895df7-af72-5733-b1b5-dab0024f072a",
+          "_name": "Repurpose"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f3b82cfa-ab7d-53b2-9931-91d3cd876f78",
+          "_name": "Thwip Thwip!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6829d654-2257-5e52-8e4d-14a14a3d3a70",
+          "_name": "Energy Barrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d329c8db-067c-54b4-8393-6c9456e22577",
+          "_name": "Forcefield Generator"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e0c9f00b-ad66-5cd5-921f-0fa21d538d1c",
+          "_name": "Spider-Tingle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5c65f165-bc7a-5057-a26b-1e44a11fcb81",
+          "_name": "Spider-Ham"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d32c0cfb-cae4-53f7-9739-eb3e962b4b3d",
+          "_name": "Spider-Man"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b1373307-00c0-5264-a2bc-f20da17cd1ab",
+          "_name": "Limitless Stamina"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "91f6a8ff-ad1b-5760-86b1-ead7d50e6000",
+          "_name": "Unshakable"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a7442ad5-0454-5757-8982-7283f688be07",
+          "_name": "Inherited Burden"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dc3b9db3-b828-5d70-9a3d-481d0a4e11dc",
+          "_name": "Giant Monster Attack"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e2a0786-ec19-5212-b20d-9746c856377f",
+          "_name": "M.O.R.B.I.U.S."
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "50052124-b233-54d4-8691-ccb66fc8ae01",
+          "_name": "Energy Drain"
+        }
+      ]
+    },
+    "SP\/\/dr Nemesis": {
+      "label": "SP\/\/dr Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dc3b9db3-b828-5d70-9a3d-481d0a4e11dc",
+          "_name": "Giant Monster Attack"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e2a0786-ec19-5212-b20d-9746c856377f",
+          "_name": "M.O.R.B.I.U.S."
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "50052124-b233-54d4-8691-ccb66fc8ae01",
+          "_name": "Energy Drain"
+        }
+      ]
+    },
+    "Iron Spider's Sinister Six": {
+      "label": "Iron Spider's Sinister Six",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "24bf9a84-a6e4-5ac6-b29a-c7faa7f05c9b",
+          "_name": "Grand Larceny"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "06c68851-4572-52e6-9c10-a60138beee68",
+          "_name": "Bombshell"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d255587a-443e-5666-a77a-ab904c618843",
+          "_name": "Electro"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "303a0cae-361d-5bd4-981d-ac8673a00edb",
+          "_name": "Hobgoblin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7ab7df9b-c771-55d6-a136-ef7d0bb10e86",
+          "_name": "Iron Spider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e8065cc5-3a35-51f1-9b7f-7c3646e7b70f",
+          "_name": "Sandman"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e17ebc79-00df-56e5-8ab7-d0ad9bbd6e95",
+          "_name": "Spot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b5e3c887-e7a9-5b59-93a7-e65a03052d6b",
+          "_name": "Surge in Crime"
+        }
+      ]
+    },
+    "Colossus": {
+      "label": "Colossus",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "70efe9ca-38c2-526c-b9aa-cf0258c11ded",
+          "_name": "Piotr Rasputin"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "18a2fa79-7f9a-5bd8-bc4c-3648fbc7855d",
+          "_name": "Shadowcat"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb9ceea8-7ef8-51ab-b0b1-ff5780b2ea0d",
+          "_name": "Piotr's Studio"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1a15416d-6b6e-5d71-bc68-ee676eb47681",
+          "_name": "Iron Will"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4f0aeca0-7368-5aff-bb49-03bb0ebe5da0",
+          "_name": "Titanium Muscles"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "1a08c097-3400-5535-9608-16a9b1909193",
+          "_name": "Organic Steel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d65d8945-c1ae-534e-a4bf-067116f977e2",
+          "_name": "Made of Rage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6b66c339-cfbd-5e99-bc1a-e172244e61fd",
+          "_name": "Steel Fist"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "17174c39-de02-5ded-a1bd-521832e8f4c5",
+          "_name": "Bulletproof Protector"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "78517161-9b3f-5b95-a657-817a787846af",
+          "_name": "Armor Up"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7c01d4d1-5c38-5357-a1d7-4ec29472401b",
+          "_name": "Nightcrawler"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f269290b-4b5f-5c8d-9153-a309eb1769d5",
+          "_name": "Polaris"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "efd9e91c-fb17-5d13-822d-39514cf9cd76",
+          "_name": "Protective Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c643fdc3-b4e9-5209-95de-e4c6e82f0d00",
+          "_name": "Powerful Punch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "13835646-14cf-55dd-ae2b-5259e3fdbe79",
+          "_name": "Bait and Switch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "cb5f62b9-8e33-570b-940c-502a655c1783",
+          "_name": "Perseverance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "75e64d60-d0f5-5667-8650-476cbd116a97",
+          "_name": "Mutant Protectors"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9693263f-2994-552a-9467-683b99215b53",
+          "_name": "Defensive Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "de779927-5f85-59b3-8333-c12882c1d130",
+          "_name": "Professor X"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8ea28c1e-00da-531a-86fa-ab866ec04b76",
+          "_name": "The X-Jet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d393444c-0dac-5e43-b0f9-b8a7fd735119",
+          "_name": "Shadow and Steel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ef40dcd5-edd9-53ae-a594-e687150e7b7c",
+          "_name": "Homesick"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "203b16bf-638c-5638-9a04-e22b99f1cae4",
+          "_name": "Juggernaut"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c9e07021-7b3d-52b1-9d91-e5b5ef04558b",
+          "_name": "Rampaging Juggernaut"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "534d5409-2557-5289-ab0f-1f27d0fcc4ff",
+          "_name": "Unstoppable"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3902bc2c-d811-5fc5-9f27-d967664f1143",
+          "_name": "Slammed"
+        }
+      ]
+    },
+    "Colossus Nemesis": {
+      "label": "Colossus Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "203b16bf-638c-5638-9a04-e22b99f1cae4",
+          "_name": "Juggernaut"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c9e07021-7b3d-52b1-9d91-e5b5ef04558b",
+          "_name": "Rampaging Juggernaut"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "534d5409-2557-5289-ab0f-1f27d0fcc4ff",
+          "_name": "Unstoppable"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3902bc2c-d811-5fc5-9f27-d967664f1143",
+          "_name": "Slammed"
+        }
+      ]
+    },
+    "Shadowcat": {
+      "label": "Shadowcat",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "fca7c463-b072-5903-8a83-799fd072c27b",
+          "_name": "Kitty Pryde"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "eb0dba10-1e47-5fc6-8b35-c7bebbf97f6a",
+          "_name": "Solid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "80847775-3f25-552b-b28a-e2014f732f1e",
+          "_name": "Lockheed"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4297f171-0754-5228-a482-ba5a21674b21",
+          "_name": "Kitty's Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "99a4cc70-4c8e-544f-9b89-527069256e23",
+          "_name": "Acute Control"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "081a52c7-9f85-58f8-9218-6bb0147a96b8",
+          "_name": "Intangible Interference"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4106d737-720b-5ab0-bd90-6192e2214992",
+          "_name": "Phased and Confused"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "eac5ad7f-a23d-5627-9d1e-aab27bccf95a",
+          "_name": "Shadowcat Surprise"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ddec7dda-6fa2-50e9-a192-b7f34044e5c2",
+          "_name": "Phased Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "cfc81578-7dc6-5864-ab8f-b5a8f6cf3795",
+          "_name": "Airwalk"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "26e08868-4ee4-571b-baab-1514bd825dcd",
+          "_name": "Quick Shift"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8cdf5dde-8579-5c05-95ee-46730543eeec",
+          "_name": "Wolverine"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3582e512-0585-586f-b3d7-64f7c539f788",
+          "_name": "Magik"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ae4908be-35ab-571f-999c-7249cab9d600",
+          "_name": "Attack Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "66820ca9-ef1b-5560-9894-87f0313b0dd5",
+          "_name": "Gatekeeper"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "fa741e61-184a-5203-8631-4701aeeee41a",
+          "_name": "Team Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e7f91095-33c3-58d9-bf52-dcb080f587dd",
+          "_name": "Toe to Toe"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4a2de124-00fc-5ed3-a22a-c664be19e3dc",
+          "_name": "Aggressive Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "be4921a1-0aca-59c4-a2a3-226d932a88c2",
+          "_name": "Colossus"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4b589f6e-c526-58bb-8709-9fdd9e581875",
+          "_name": "X-Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d393444c-0dac-5e43-b0f9-b8a7fd735119",
+          "_name": "Shadow and Steel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c8f6bf16-68c2-52f5-baf0-77270992a749",
+          "_name": "Ready to Rumble"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "8b596b6c-f0ed-5e9b-9c3c-a1629edd2f56",
+          "_name": "Permanently Phased"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ca74cb21-fd9e-556c-8ab9-4431782f44a5",
+          "_name": "White Queen"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2315085d-0f55-5f0c-8fc2-52b0867bc216",
+          "_name": "The Hellfire Club"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "7a02b51d-0608-5a57-baea-8b811364054a",
+          "_name": "Hellfire Pawn"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7b1a8f3a-8efa-52c7-bda3-fd91329fc943",
+          "_name": "Telepathic Restraint"
+        }
+      ]
+    },
+    "Shadowcat Nemesis": {
+      "label": "Shadowcat Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ca74cb21-fd9e-556c-8ab9-4431782f44a5",
+          "_name": "White Queen"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2315085d-0f55-5f0c-8fc2-52b0867bc216",
+          "_name": "The Hellfire Club"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "7a02b51d-0608-5a57-baea-8b811364054a",
+          "_name": "Hellfire Pawn"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7b1a8f3a-8efa-52c7-bda3-fd91329fc943",
+          "_name": "Telepathic Restraint"
+        }
+      ]
+    },
+    "Sabretooth": {
+      "label": "Sabretooth",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3eeb861a-bfe7-5b98-aa18-8143421f3544",
+          "_name": "Sabretooth"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "a3c2f621-b41a-51ac-bfa8-408761437915",
+          "_name": "Sabretooth"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "9d27b82b-b15a-51f4-9a76-27f3da0a848a",
+          "_name": "Sabretooth"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "09461298-8222-5419-b24b-61e32980ac31",
+          "_name": "Stalked by Sabretooth"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "a94e5dd1-c04d-59f8-87e7-874dbf848892",
+          "_name": "The Injured Senator"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "28758196-9921-56b4-81b5-2f47dd4fe362",
+          "_name": "Find the Senator"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9792121b-15cb-572c-be92-bf7013d44d17",
+          "_name": "Robert Kelly"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "aeb57f9d-ee37-5bbc-bf20-6c806888cafc",
+          "_name": "Adamantium Claws"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "33d9b58c-35c4-547d-86fb-e731d27b1889",
+          "_name": "Animal Ferocity"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d74df461-dfb1-54f1-b434-82280e50caea",
+          "_name": "Sabretooth Strikes"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "f4abe9aa-8161-5594-b685-1dd82d0f7ca2",
+          "_name": "Unrelenting Savage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7bc2aa79-ceb8-539a-b2a4-571f8539f84a",
+          "_name": "Medical Emergency"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "32de8146-483a-529b-bed9-d58f2021f8b0",
+          "_name": "Feral Rage"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Sabretooth"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Brotherhood": {
+      "label": "Brotherhood",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e4d371f-121a-5026-a95f-d1cf018c9935",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "249f2dba-16bd-5926-b90d-713184a7231d",
+          "_name": "Blob"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "829f832a-4c4d-5ebe-8fd5-e733a7ee4cf8",
+          "_name": "Pyro"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adb49983-fa24-5a6f-b0e1-3c927a0a7f78",
+          "_name": "Toad"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c46d681c-43fa-58ed-88b9-d842c269dda7",
+          "_name": "Homo Superior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c09d7f-e00d-5c5e-8572-2815c7a1d5db",
+          "_name": "Mutant Terrorists"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12741201-1920-59b0-b7a7-828565eee855",
+          "_name": "The Brotherhood"
+        }
+      ]
+    },
+    "Mystique": {
+      "label": "Mystique",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "04c2cb0d-d2e1-50d0-8847-f59a98be90be",
+          "_name": "Mystique"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bd5618c0-3181-5439-9bb3-03d508a84fca",
+          "_name": "Metamorphic Mayhem"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8ba27fcf-288a-56f2-ac4a-a80cd554230d",
+          "_name": "Infiltration"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cbbdc5dd-bb0c-5916-a273-2cf387e1e060",
+          "_name": "Shapeshifter Surprise"
+        }
+      ]
+    },
+    "Project Wideawake": {
+      "label": "Project Wideawake",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "a46599c0-d3fc-5ee3-9772-27a512c9877c",
+          "_name": "Abduction Protocols"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "ea4cd95b-f695-501a-bbce-af9133101f10",
+          "_name": "Sentinel"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "508f4ff8-d451-5fb2-a7da-91eb19619f31",
+          "_name": "Sentinel"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "8956e6bb-6206-5820-a8b8-6b15da45d032",
+          "_name": "Sentinel"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "8d737665-c9f7-56d9-b0bc-6525fc4fbb74",
+          "_name": "Night of the Sentinels"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "08432c81-4f4b-555d-a6cd-89d9711781f2",
+          "_name": "Mutants at the Mall"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "94fb040c-66a2-5113-b16a-b919d9dac1d7",
+          "_name": "Rictor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2777270b-1879-59e8-8dfe-11bc19dc9fbe",
+          "_name": "Boom Boom"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "59d50d2e-ca84-593e-ba80-ec9ab310bcb8",
+          "_name": "Cannonball"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "750d69ec-aee3-57d5-8e42-85ae0aee99b5",
+          "_name": "Wolfsbane"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "030c0786-d3a2-54e8-96e8-dde6182491f7",
+          "_name": "Sentinel Mark IV"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1194078c-a2c2-5f83-9431-c1f1c3b93161",
+          "_name": "Gauntlet Beam"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4093262f-13af-5089-8c2a-1909bdaf887c",
+          "_name": "Learning A.I."
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eae70a43-e4ef-5708-95ff-f4d473eee36c",
+          "_name": "Adaptive Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "afb6eeca-84f0-58c5-8f0a-d8aeb75f0dbb",
+          "_name": "Self-Repair"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7d8074f4-19ae-5e6d-810e-9d5a5d4f6738",
+          "_name": "Mutant Detected"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "146478d2-b684-511c-87b3-671d1449e7b8",
+          "_name": "Warn the Others"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Project Wideawake"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Project Wideawake"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Zero Tolerance": {
+      "label": "Zero Tolerance",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "76a17f90-2129-5d2f-a92a-3b93fdc78bf9",
+          "_name": "Sentinel Mark II"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "39d48355-58a9-55cc-88f8-d2d9e8776a09",
+          "_name": "Sentinel Mark III"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "668e0cb6-0315-5e2a-85ab-a22f79e6e22e",
+          "_name": "Energy Barrier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c65aa8ac-ee8b-527c-8d66-ae62e5a9f77f",
+          "_name": "Operation Zero Tolerance"
+        }
+      ]
+    },
+    "Sentinels": {
+      "label": "Sentinels",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6bff7ff9-7812-5307-a87c-fd87fe934051",
+          "_name": "Sentinel Mark V"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ac2da7ef-a326-5519-96d4-b60bf66aa7bf",
+          "_name": "Sentinel Mark VI"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5b8721de-ccf1-58e3-a659-da10eb85a9da",
+          "_name": "Targeted for Elimination"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dee7b19d-f15a-57f3-aadb-c1e7b7788cbc",
+          "_name": "Relentless Robots"
+        }
+      ]
+    },
+    "Master Mold": {
+      "label": "Master Mold",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "aed4c402-8c76-5e2c-9664-7767c41e78e5",
+          "_name": "Master Mold"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "8f1adc22-325b-5c64-b522-65da6f2fa5fd",
+          "_name": "Master Mold"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d7f12f25-5d08-5d61-ba11-578141211606",
+          "_name": "Master Mold"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "cf008806-a37b-5978-9b07-b26dda53d204",
+          "_name": "The Sentinel Factory"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "a1ffd870-395d-5e37-97e7-3e734120a28d",
+          "_name": "Master Mold's Agenda"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "dc48ec2f-1962-5fe2-b7a5-a1df51e54b6a",
+          "_name": "Sentinel Mark VIII"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "720b8ebe-7345-5cd0-817a-33f181464f88",
+          "_name": "Unit Upgrade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "652666d1-dde8-5893-a7c9-8bf5b39eb905",
+          "_name": "Stun Beam"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f60eb543-0d30-51d1-9930-e0e05daf5d12",
+          "_name": "Master Mold's Children"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "02f55153-f4fa-5ba7-b200-22db2ae3b4ec",
+          "_name": "Shields Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "006a94a7-dd12-5245-832a-2bdce1aa82a4",
+          "_name": "Intruder Alert!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3a748313-aa48-5ff4-b9ce-3d68533786bf",
+          "_name": "Insert Virus Program"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Master Mold"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Master Mold"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Mansion Attack": {
+      "label": "Mansion Attack",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7e7571bc-3d50-53ba-b92c-421854eabc96",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7332b996-a58f-593b-8806-c476c732f5a7",
+          "_name": "Blob"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "df9d7010-d9ae-5779-b8bd-d83a2b59d866",
+          "_name": "Pyro"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d1dc807a-0356-54c2-b576-c6590f9c8946",
+          "_name": "Toad"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "9bd4ebfc-00ed-51b4-a981-acaec5994f93",
+          "_name": "The Brotherhood Strikes!"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "03f73eef-eb03-5257-9619-2f48ac1ac04e",
+          "_name": "Attack on Xavier's"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "8de35593-c522-5e32-b32a-e2e04a99daed",
+          "_name": "Attack on Xavier's"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "cedcf047-14f2-50bd-a270-52e2a2c4a640",
+          "_name": "Attack on Xavier's"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "36ce4a2d-7674-5036-9268-e03e2b00ef49",
+          "_name": "Attack on Xavier's"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "25faac83-b62d-5de1-bd4a-72de30f6ae57",
+          "_name": "Save the School"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "b3506ea3-dc35-5339-9fd9-8fd55c0846d6",
+          "_name": "Brotherhood Beatdown"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "e0a440e1-4f1b-515d-8405-ee2a9d4fc439",
+          "_name": "Ground Swell"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8094cac8-1f39-52d2-aa93-035de8a11a32",
+          "_name": "Immovable"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3a45d640-c4ac-5400-bc82-1b3c65426cd5",
+          "_name": "Pyromaniac"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7a197450-f7bf-5434-b0cd-f887166f2982",
+          "_name": "Hopping Mad"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8863ce54-b586-50ca-bbea-e62b66da3bb9",
+          "_name": "Protect the Students"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c4293643-330d-5228-9d96-a6a833d586a7",
+          "_name": "Under Siege"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Mansion Attack"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Mansion Attack"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Magneto": {
+      "label": "Magneto",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "433481e6-0a8b-578c-9101-6c85c8a3ee78",
+          "_name": "Magneto"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "863259a7-2208-532d-aedd-9d3a3e6c7602",
+          "_name": "Magneto"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "236934ec-178d-5271-a489-cf84c2d393ba",
+          "_name": "Magneto"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "11bd84bc-ebe9-50cf-aa37-e20a9deeec91",
+          "_name": "Asteroid M"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "c8754090-20d8-5f45-8016-5e1fb0d5538f",
+          "_name": "Factory Online"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "ecf3f88f-f986-52ad-b00a-b47bdbcbe1ae",
+          "_name": "The Rule of Magnus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ada7ff58-8b8b-58f9-a3eb-db34946e2373",
+          "_name": "Boarding Party"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6165ae5f-81b8-5c31-aa2c-aff4968ec302",
+          "_name": "Orbital Decay"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "dc9debf0-1800-54bf-b6da-feb7e133c27b",
+          "_name": "M-Type Sentinel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "520af983-15ab-5ee5-9148-733e88b94859",
+          "_name": "Magneto's Helmet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "32a8fecb-3f9c-5fce-8bc2-836de3490c6e",
+          "_name": "Magneto's Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "756ba9cf-8c34-56fa-a31c-c641a8024cf3",
+          "_name": "Magnetic Bubble"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2eb0ca5e-a95c-5918-9fa2-88851cdad809",
+          "_name": "Wrapped in Metal"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0b9d4fbf-2d5b-5c81-bf86-b2c85626471a",
+          "_name": "Master of Magnetism"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fa96ce83-86c9-5eda-9aef-7daf8a01b8c5",
+          "_name": "Electric Shock"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0174ff5a-046e-5b80-9926-9481dd882062",
+          "_name": "Electromagnetic Blast"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "049c3914-ab20-54ff-af83-435b6412636b",
+          "_name": "Metal Shards"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d023bea4-faeb-5044-ba4e-959512b3a8f6",
+          "_name": "Magnetic Missile"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "40f7456d-bd1a-5a30-8732-ff589286146d",
+          "_name": "Magnetic Mayhem"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "61e42dfa-c7ae-58da-934b-ef59c172ef1f",
+          "_name": "Magnetically Sealed"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "27fc2ed2-015b-5d5b-a63e-1b980c6b137e",
+          "_name": "Seized!"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Magneto"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Acolytes": {
+      "label": "Acolytes",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f4f72a5f-bd65-52ea-ad82-cefb27ec0ef8",
+          "_name": "Fabian Cortez"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "138c924e-07c7-59bb-b2ce-baad73bb905f",
+          "_name": "Amelia Voght"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "26a02a40-f9b8-51ef-98d1-2adb47334bb8",
+          "_name": "Senyaka"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4cb80833-1f75-5496-9589-fbc4af4209b6",
+          "_name": "Delgado"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e04bdbbc-7ca6-54b3-96a8-5d3c1500e748",
+          "_name": "Unuscione"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "98c7bcfd-96b2-58e7-a797-1d4a9806671e",
+          "_name": "Zeal for the Cause"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "997b731f-eb27-51fa-b8d0-4daaed7e89e2",
+          "_name": "The Acolytes"
+        }
+      ]
+    },
+    "Future Past": {
+      "label": "Future Past",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9b9239e7-8f11-5990-b4b3-7577e7561a10",
+          "_name": "Nimrod"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dd408e47-3346-5c9b-8303-07605fa2f583",
+          "_name": "Bastion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "65474f1f-7e8f-5139-a9d9-6b5fdc47274b",
+          "_name": "Nimrod's Portal"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e2387a7c-a274-511e-9750-31fdb2991185",
+          "_name": "Bastion's Machinations"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b6eaae2d-afdd-5ebf-b007-43d9a4593d86",
+          "_name": "Nano-Sentinel Tech"
+        }
+      ]
+    },
+    "Campaign (Mutant Genesis)": {
+      "label": "Campaign (Mutant Genesis)",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "e4e13900-b1a1-51f8-bbab-454c661eb007",
+          "_name": "Frightened Police"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "7b5faa57-ba8b-5b17-9093-a6bdae538a7f",
+          "_name": "Enemy of My Enemy"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6f1b55ec-dc1b-5224-ab9b-8721a6104d74",
+          "_name": "Find the Prisoners"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "48f6d7d3-239f-5784-ab49-8f6ff6bd8288",
+          "_name": "Surprise Attack"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "307ec063-18a7-576a-9ee0-ea082fc5ed32",
+          "_name": "Magneto's Fortress"
+        }
+      ]
+    },
+    "Brawler": {
+      "label": "Brawler",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b4c1b9cf-87f0-5815-92ef-cdb7427cbb26",
+          "_name": "Coup de Grâce"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6f836181-f1a7-5f4a-8983-0fe8f355e84c",
+          "_name": "Swagger"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1066217a-9cd8-57ff-ac16-4162a2cb1303",
+          "_name": "Brazen Defense"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "90de4f81-e614-5f2d-bfc8-59a2b5c92c66",
+          "_name": "Ferocious Attack"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "7b5e8c34-00fb-57b4-bb91-8a1d94f3f106",
+          "_name": "War Cry"
+        }
+      ]
+    },
+    "Commander": {
+      "label": "Commander",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b4c1b9cf-87f0-5815-92ef-cdb7427cbb26",
+          "_name": "Coup de Grâce"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c83814e4-590e-5bae-b7a5-e0609f96c3fb",
+          "_name": "Compassion"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "27ba12bf-3631-5fdd-ba73-a3ec0dd9416a",
+          "_name": "Group Assault"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "5898248f-af4c-54a0-8529-8b25f3b05106",
+          "_name": "Shock and Awe"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b8378828-3d65-56b7-b299-74d95fdc3a4c",
+          "_name": "Improvisation"
+        }
+      ]
+    },
+    "Defender": {
+      "label": "Defender",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6f836181-f1a7-5f4a-8983-0fe8f355e84c",
+          "_name": "Swagger"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "ec244d73-1343-57e0-8637-39cf9c29c9bd",
+          "_name": "Surprise!"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "4817a195-3330-5125-ad07-b647660dc432",
+          "_name": "Heroic Intervention"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b606bdbf-f6b4-5a53-88a0-a54172f1ae5a",
+          "_name": "Determined Defense"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6deb36e4-ece0-52dd-92ac-6fe28ae628f0",
+          "_name": "Bodyguard"
+        }
+      ]
+    },
+    "Peacekeeper": {
+      "label": "Peacekeeper",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "ec244d73-1343-57e0-8637-39cf9c29c9bd",
+          "_name": "Surprise!"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c83814e4-590e-5bae-b7a5-e0609f96c3fb",
+          "_name": "Compassion"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "9496bd50-07b9-5410-9f90-b242e81481ce",
+          "_name": "Rescue Operation"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "f81e6590-4b31-58cc-8e6a-655db90ddb72",
+          "_name": "Mentorship"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "e5eb2f73-639a-5b6a-8b76-91d588863b2d",
+          "_name": "Fortitude"
+        }
+      ]
+    },
+    "Cyclops": {
+      "label": "Cyclops",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "323009fa-7d7a-582e-b698-e8d45e1b9538",
+          "_name": "Scott Summers"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "07951ee8-63b9-59b0-b32a-e97ecc4e2807",
+          "_name": "Phoenix"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f63312ca-3cc0-5495-ace8-8989336fc473",
+          "_name": "Ruby Quartz Visor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6ad9a04b-fb24-58d9-b0ef-bfa3f4afe690",
+          "_name": "Field Commander"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "30985986-fa99-5f8e-8866-e590f062b69e",
+          "_name": "Exploit Weakness"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "3980ff34-66d0-521f-96a1-57bb9d605c01",
+          "_name": "Practiced Defense"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "47620469-0caa-5c18-8ca6-26a47605d6f9",
+          "_name": "Priority Target"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "64d79431-a085-599a-b465-7be46f524f1d",
+          "_name": "Full Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "257bfce6-f708-5451-8362-414898ea48f5",
+          "_name": "Ricochet Beam"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "fcfd9489-86b6-500c-84db-69bda5d1f593",
+          "_name": "Tactical Brilliance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d9418785-2cac-5920-8b7a-819a3ee5e376",
+          "_name": "Beast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "40e25fd5-c2c3-5123-ad22-ad3740d097da",
+          "_name": "Dust"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0bef460e-063d-5351-a105-4c51cd6d91b9",
+          "_name": "Rockslide"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "68216926-2e06-5661-b6bc-aa3635fa5a9c",
+          "_name": "Blindfold"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f630cc3b-c34e-5c9b-9ef7-0e6dc94d0807",
+          "_name": "Danger Room Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "cc836458-5980-52c8-89da-db297eb0b216",
+          "_name": "Coordinated Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6fca8e1c-45c3-52d8-a346-b22d8d2b85a3",
+          "_name": "Teamwork"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "7eb0fc41-749b-5bcd-8e07-37442c0def6c",
+          "_name": "Effective Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2c4bb8d4-ef27-5a14-84c0-3dc490697bb1",
+          "_name": "Angel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "66757696-0ba2-5741-bd17-463b96cb3f76",
+          "_name": "Utopia"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4a2d6c38-cf83-5676-a484-f87e32e5d2aa",
+          "_name": "Danger Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "50f3c2e2-f720-5ebf-9958-e5e86d00726a",
+          "_name": "Game Time"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ea7aaff1-b304-5c3e-b750-c5a46e60980f",
+          "_name": "Psychic Rapport"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9a1d1fe3-441e-585c-b3fa-4223e2cf9388",
+          "_name": "Lost Visor"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "693134be-fe55-5474-b040-79b0e723fd83",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "df1fc64d-49f4-5c95-8766-4ead875cc68e",
+          "_name": "Genetic Manipulation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "b3da2fcf-54ec-5f94-9403-2e5a14a253a3",
+          "_name": "Gene Therapy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "346efd23-9edf-56e2-90e9-28c7fc91a66e",
+          "_name": "Concussive Force"
+        }
+      ]
+    },
+    "Cyclops Nemesis": {
+      "label": "Cyclops Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "693134be-fe55-5474-b040-79b0e723fd83",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "df1fc64d-49f4-5c95-8766-4ead875cc68e",
+          "_name": "Genetic Manipulation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "b3da2fcf-54ec-5f94-9403-2e5a14a253a3",
+          "_name": "Gene Therapy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "346efd23-9edf-56e2-90e9-28c7fc91a66e",
+          "_name": "Concussive Force"
+        }
+      ]
+    },
+    "Phoenix": {
+      "label": "Phoenix",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "2c1d1f38-fe42-504d-9e70-b0112062f399",
+          "_name": "Jean Grey"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "81397765-eb25-5404-975a-97e9c75bf4f1",
+          "_name": "Phoenix Force"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a5c6e84b-c65f-503c-b120-cb692b1a615f",
+          "_name": "Cyclops"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bd8444ae-5df6-5bb9-8bbd-461f6f1f3055",
+          "_name": "White Hot Room"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6f61ee9f-0290-543c-8f1b-702d427fcd63",
+          "_name": "Phoenix Suit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "256f2973-bf69-54ca-aec8-9c88049ca7c4",
+          "_name": "Rise from the Ashes"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ea5423bc-4016-53b8-ae8f-3268afb3c720",
+          "_name": "Telekinetic Shield"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5b9ddabb-6c02-5407-b84f-c2e2cc48124b",
+          "_name": "Mental Paralysis"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "354f4d14-2fd4-56c3-80d7-29a72c0a0829",
+          "_name": "Mind Control"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ce8eca39-4dc5-5503-9403-ed5b3f79b455",
+          "_name": "Telekinetic Attack"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "d499110a-3609-5a46-ae06-aec18f6de781",
+          "_name": "Psychic Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2ab0b79c-d466-5b3d-808f-0e38956a4f82",
+          "_name": "Telepathic Trickery"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e8b5ae83-9fce-52a0-9232-a73d7e3afbe6",
+          "_name": "Phoenix Firebird"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0183a4bb-6007-5f75-a24e-d91ca1e06145",
+          "_name": "Banshee"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "02ecd09d-0661-5471-b071-de081a174afc",
+          "_name": "Marvel Girl"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c0d9dd7e-f79e-5115-803e-43d9351c5342",
+          "_name": "Mission Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "51244972-fcc2-5f4b-8784-ffec43fb968e",
+          "_name": "Psychic Manipulation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "89d59f90-bc62-5d17-87db-f37d6dbd86ba",
+          "_name": "Mutant Peacekeepers"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5d8ab240-c894-5321-9af6-cf8c71cee612",
+          "_name": "Swift Retribution"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "7f515490-ee4a-5eb8-be68-ac605a91c27d",
+          "_name": "Passion for Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0021433f-c89a-5eb9-863a-1fd78300db95",
+          "_name": "Storm"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7402b6fe-c1c2-559b-9cb6-71669336606f",
+          "_name": "Cerebro"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ea7aaff1-b304-5c3e-b750-c5a46e60980f",
+          "_name": "Psychic Rapport"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "afc71589-173e-5cd3-b120-f70313e07c7c",
+          "_name": "Down Time"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "13213966-29c7-578e-9f93-0196cc33ada1",
+          "_name": "Burning Hunger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4ddb5a14-d451-5461-bd5f-0b06a9149ff7",
+          "_name": "Dark Phoenix"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7b5bf070-c823-5529-9d83-bb8536702dd3",
+          "_name": "Consume the World"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "f1701c79-ffe4-5acb-a6ab-9de7f8d85067",
+          "_name": "Fiery Rage"
+        }
+      ]
+    },
+    "Phoenix Nemesis": {
+      "label": "Phoenix Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4ddb5a14-d451-5461-bd5f-0b06a9149ff7",
+          "_name": "Dark Phoenix"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7b5bf070-c823-5529-9d83-bb8536702dd3",
+          "_name": "Consume the World"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "f1701c79-ffe4-5acb-a6ab-9de7f8d85067",
+          "_name": "Fiery Rage"
+        }
+      ]
+    },
+    "Wolverine": {
+      "label": "Wolverine",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "574254b7-2ecd-5a6f-a6ad-b69ca9cc34ea",
+          "_name": "Logan"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "b528b244-5df7-5977-8d8e-c057a2f42432",
+          "_name": "Wolverine's Claws"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "fea4137d-4969-537c-9a5b-b75458b9e681",
+          "_name": "Jubilee"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9f14f0e1-4708-5130-9e81-47481a68c9e1",
+          "_name": "Adamantium Skeleton"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6253fb0b-b410-5f5b-9709-477713c3f280",
+          "_name": "Berserker Frenzy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7e6ebff9-7d71-5241-94e1-6b877c675c54",
+          "_name": "\"I Got Better\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a163ddbf-ed62-51c7-8e7a-b1b64fa4997c",
+          "_name": "Logan's Cabin"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ccbbe578-d098-59b7-86c0-c907f2faaef3",
+          "_name": "Berserker Barrage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "efacc959-948f-5e3c-870f-5562e7ecce43",
+          "_name": "Slice and Dice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "beef8cc5-0088-5e0f-bbdc-d1c2a27308ef",
+          "_name": "Lunging Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "0c376fcf-ebc9-545f-a19a-aee865381d80",
+          "_name": "Track by Scent"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "5236b570-10ad-5d4f-bc56-769d6e160848",
+          "_name": "Regenerative Healing"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "01266d71-47b7-5be7-b33f-09e6a1f5c04c",
+          "_name": "Psylocke"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ec21033a-5805-5638-b4fa-f6d65ee28c8a",
+          "_name": "Sunfire"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a60533b4-33b1-5ccf-aabd-bfb00902f0ec",
+          "_name": "Battle Fury"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "974e5ed8-9ca2-5eed-b9f1-5cb077df32c0",
+          "_name": "Warrior Skill"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ff45fa64-dd5d-5c58-8a13-0d68b6b945d6",
+          "_name": "Outta My Way!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f82e32a4-096f-57e3-bdac-04305c09cd99",
+          "_name": "Precision Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e7c6dc4e-ab8d-5f53-9046-3f259bb89d4b",
+          "_name": "Mean Swing"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4a2de124-00fc-5ed3-a22a-c664be19e3dc",
+          "_name": "Aggressive Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "be4921a1-0aca-59c4-a2a3-226d932a88c2",
+          "_name": "Colossus"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "82917f7a-edf1-555a-9476-0fce902c3649",
+          "_name": "Weapon X"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "fe9531a4-8e1d-5872-b5d0-9c84e1b84153",
+          "_name": "Fastball Special"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bc87c9b4-a796-5b66-858b-58652dd898f5",
+          "_name": "Past Demons"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "70d3dc78-c085-53be-a62c-9c924ad5379b",
+          "_name": "Omega Red"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4766ef75-9673-5ecf-a018-75c2fdcb878d",
+          "_name": "The Carbonadium Synthesizer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "e2dff0f1-9464-5936-ae7a-d736a6c1cb33",
+          "_name": "Death Factor"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cd4f7476-0040-5d74-bc01-cd477e6c8319",
+          "_name": "Tentacle Strike"
+        }
+      ]
+    },
+    "Wolverine Nemesis": {
+      "label": "Wolverine Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "70d3dc78-c085-53be-a62c-9c924ad5379b",
+          "_name": "Omega Red"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4766ef75-9673-5ecf-a018-75c2fdcb878d",
+          "_name": "The Carbonadium Synthesizer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "e2dff0f1-9464-5936-ae7a-d736a6c1cb33",
+          "_name": "Death Factor"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cd4f7476-0040-5d74-bc01-cd477e6c8319",
+          "_name": "Tentacle Strike"
+        }
+      ]
+    },
+    "Deathstrike": {
+      "label": "Deathstrike",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12ccc827-3782-541c-a8ac-a5d0adf04fb4",
+          "_name": "Lady Deathstrike"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fb4b37f5-4099-5910-9eb2-7e90f5ce3a7c",
+          "_name": "Seeking Vengeance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "bc5cfbdc-0ed5-5d21-9004-c71dadc2f23a",
+          "_name": "Adamantium Upgrades"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3176a069-83ed-530e-8dc7-d04bf846b8e2",
+          "_name": "Hack 'n' Slash"
+        }
+      ]
+    },
+    "Weather Deck": {
+      "label": "Weather Deck",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "f5efa387-352e-58ba-95d8-ab9035a93e06",
+          "_name": "Clear Skies"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "e8811db5-3e27-5258-9edd-f1b7f7b01f20",
+          "_name": "Hurricane"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "f250dd0a-5017-5fc0-b3d8-844b1a5c1350",
+          "_name": "Thunderstorm"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "02a55622-2844-53da-b8fb-53c4f2d3a4c5",
+          "_name": "Blizzard"
+        }
+      ]
+    },
+    "Storm": {
+      "label": "Storm",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "f2476b12-9b49-5c2b-ba30-0a2b20c431a2",
+          "_name": "Ororo Munroe"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "f5efa387-352e-58ba-95d8-ab9035a93e06",
+          "_name": "Clear Skies"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "e8811db5-3e27-5258-9edd-f1b7f7b01f20",
+          "_name": "Hurricane"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "f250dd0a-5017-5fc0-b3d8-844b1a5c1350",
+          "_name": "Thunderstorm"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "02a55622-2844-53da-b8fb-53c4f2d3a4c5",
+          "_name": "Blizzard"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9c54a29-904a-5537-811f-61f3af9763a3",
+          "_name": "Storm's Crown"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "25d41d06-007e-5759-b03e-4f5644542dc5",
+          "_name": "Storm's Cape"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bdaf2763-1156-5bb1-bf32-dc47544e0a7e",
+          "_name": "Ororo's Garden"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f0bcac32-53cd-5a55-b75d-b0f48ce0bf46",
+          "_name": "Weather Goddess"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8c2f035e-919a-51d9-a88c-ae4cb5895c18",
+          "_name": "Torrential Rain"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c5224899-fbbb-5d3b-a487-c7b808ec2c99",
+          "_name": "Lightning Bolt"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "1bb3067a-0a7e-5f2a-8ce2-dcee06ea8956",
+          "_name": "Flash Freeze"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "4f8a9eac-c40d-5863-878f-c29fa463397e",
+          "_name": "Blast of Wind"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6d3899cf-e1ff-58db-83bf-4550d858b1b8",
+          "_name": "Havok"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4d854259-3c02-5027-81f4-38e71de7748c",
+          "_name": "Mirage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "68c0066a-a838-5908-82ef-6c3384a77588",
+          "_name": "Gentle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "22a3aebb-84de-500e-a52d-c4c5aadb9792",
+          "_name": "Pixie"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c876913e-168f-5836-b594-454eb0033811",
+          "_name": "Uncanny X-Men"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "438f2ca2-ad41-52f4-b1fb-b5c332bd52ba",
+          "_name": "Leadership Skill"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7f6f8d1c-7788-5d49-8953-ef0461700554",
+          "_name": "\"To Me, My X-Men!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "7eb0fc41-749b-5bcd-8e07-37442c0def6c",
+          "_name": "Effective Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b9599813-0a77-5030-975a-757cb9051fc5",
+          "_name": "Forge"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8ea28c1e-00da-531a-86fa-ab866ec04b76",
+          "_name": "The X-Jet"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "66757696-0ba2-5741-bd17-463b96cb3f76",
+          "_name": "Utopia"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4b589f6e-c526-58bb-8709-9fdd9e581875",
+          "_name": "X-Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9dea3718-60f9-5b5f-9a49-f692f21e819c",
+          "_name": "Endurance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "812fd07a-67d2-5a41-bc20-5cd10ea8714c",
+          "_name": "Claustrophobia"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "aa650bb8-1a52-54c7-960f-4935da33fd92",
+          "_name": "Callisto"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1228f8c0-c3b5-5457-95ad-7652f2a8f45b",
+          "_name": "Leader of the Morlocks"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bfa5d40b-40ca-5448-94bf-3d0cf13ae5f0",
+          "_name": "Switchblade"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "69115abc-91e8-5852-8469-23ff7cffe356",
+          "_name": "Knife Fight"
+        }
+      ]
+    },
+    "Storm Nemesis": {
+      "label": "Storm Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "aa650bb8-1a52-54c7-960f-4935da33fd92",
+          "_name": "Callisto"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1228f8c0-c3b5-5457-95ad-7652f2a8f45b",
+          "_name": "Leader of the Morlocks"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bfa5d40b-40ca-5448-94bf-3d0cf13ae5f0",
+          "_name": "Switchblade"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "69115abc-91e8-5852-8469-23ff7cffe356",
+          "_name": "Knife Fight"
+        }
+      ]
+    },
+    "Shadow King": {
+      "label": "Shadow King",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "59331cb1-822d-5c45-a00e-0d99613d7b98",
+          "_name": "The Shadow King"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1588a2c4-76ca-5bec-bbcf-403a52dbbe17",
+          "_name": "Ruler of the Astral Plane"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "812d6201-15ad-597f-be0a-14f4019fb525",
+          "_name": "Possessed"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7e4ff350-091f-5830-92b4-c1dc634bc46f",
+          "_name": "Astral Attack"
+        }
+      ]
+    },
+    "Gambit": {
+      "label": "Gambit",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "334b32dc-ae89-5cac-a0fd-75771d81cc42",
+          "_name": "Remy LeBeau"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4357e7cc-5627-53b9-b489-34f56b0ac866",
+          "_name": "Rogue"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c66cb253-3c60-5e62-bdf6-3a617784d9e0",
+          "_name": "The Thieves Guild"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f0dc338b-ba9f-5808-b93f-59f98c78f7c4",
+          "_name": "Gambit's Staff"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "23502a6d-a37c-5f55-a332-15306b08027e",
+          "_name": "Gambit's Guild Armor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "47f98c50-58a2-5622-9e27-37b50d8673aa",
+          "_name": "Charged Card"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "88e65b1f-8717-58dc-8fa9-44369b8eac55",
+          "_name": "Royal Flush"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "f30cab08-0049-5990-905c-70381dd1c9a3",
+          "_name": "Natural Agility"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b5813db0-0e6b-5c6b-82da-7212f622e5d6",
+          "_name": "Creole Charmer"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa384e4a-35ae-5bcf-a1d6-757cc2170f17",
+          "_name": "Molecular Acceleration"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "52ca4f3d-0b10-51c0-ac7d-408de032fb97",
+          "_name": "Bishop"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "fa672349-4903-575b-90fa-8132571c8845",
+          "_name": "Dazzler"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9589b61b-4c8c-5cb4-88b3-85c28ac8ccb9",
+          "_name": "Operative Skill"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "73c1f881-8ce6-5436-af98-7a37bc373e1b",
+          "_name": "Stealth Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f5606fff-e908-5668-97a4-d1f5e23dc781",
+          "_name": "Breaking and Entering"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "7f515490-ee4a-5eb8-be68-ac605a91c27d",
+          "_name": "Passion for Justice"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "de779927-5f85-59b3-8333-c12882c1d130",
+          "_name": "Professor X"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4b589f6e-c526-58bb-8709-9fdd9e581875",
+          "_name": "X-Mansion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c31521fd-7968-5fba-8adf-9a2f8c4be001",
+          "_name": "Beauty and the Thief"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "4ebf9090-b8ac-597f-8f90-3b41e308b653",
+          "_name": "Hit and Run"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "97f97ff6-f194-5257-8db9-67f28895f6e1",
+          "_name": "Mutant Education"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "82553ca6-1e12-5e65-8fd4-0aab4ddc174a",
+          "_name": "Guild Business"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8396636d-b794-5d09-8e88-9c298f6917d7",
+          "_name": "Belladonna"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ed06e4bd-7f06-573e-b7c8-5dd7fbc54ab5",
+          "_name": "The Assassins Guild"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ab888ed8-d1c9-5676-a272-26116fc89f15",
+          "_name": "Guild Assassin"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5526c793-d0a4-505a-bae5-a0e6f2a23988",
+          "_name": "Assassination Attempt"
+        }
+      ]
+    },
+    "Gambit Nemesis": {
+      "label": "Gambit Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8396636d-b794-5d09-8e88-9c298f6917d7",
+          "_name": "Belladonna"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ed06e4bd-7f06-573e-b7c8-5dd7fbc54ab5",
+          "_name": "The Assassins Guild"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ab888ed8-d1c9-5676-a272-26116fc89f15",
+          "_name": "Guild Assassin"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5526c793-d0a4-505a-bae5-a0e6f2a23988",
+          "_name": "Assassination Attempt"
+        }
+      ]
+    },
+    "Exodus": {
+      "label": "Exodus",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ef78ef58-588d-5cb1-956c-4f85d720d86f",
+          "_name": "Exodus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fc8aa69b-043a-58b5-8a43-1789560c83bf",
+          "_name": "Herald of Avalon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "70af6ced-d3bb-530c-9721-8ea593d7b7cf",
+          "_name": "Psionic Shield"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "07d06b82-042b-5aa7-86d7-e927949f9f9a",
+          "_name": "Acolyte Frenzy"
+        }
+      ]
+    },
+    "Rogue": {
+      "label": "Rogue",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "c1c26a73-a663-5b85-8030-e9a238bef216",
+          "_name": "Anna Marie"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "9a11225a-84cd-5f63-9a38-45f0c5f95db1",
+          "_name": "Touched"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "df5777d8-b094-5134-9285-76062592bc1d",
+          "_name": "Gambit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5dc746d5-995b-5100-ab76-c1142d1d114b",
+          "_name": "Rogue's Jacket"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6c7d40b5-309c-5ea2-93a4-fa763a08ccab",
+          "_name": "Goin' Rogue"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "79f2eca5-92e9-55b0-b379-e5cf66d5af04",
+          "_name": "Southern Cross"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "725828d0-9abc-5a0a-b9e9-b81728e1d6bf",
+          "_name": "Energy Transfer"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "1a1d161e-8ac1-57bf-8b28-27cdd72472f4",
+          "_name": "Bulletproof Belle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "dfaee201-e8f2-5bc1-b9f7-715ac027affe",
+          "_name": "Superpower Adaptation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d5e32836-80be-5341-b49e-ec40f7532b4d",
+          "_name": "Iceman"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e69ef7df-ae97-5abb-a776-15d68c610395",
+          "_name": "Karma"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "83a3ec80-9985-5532-8723-1ac671a50b00",
+          "_name": "Armor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7554c171-75be-5929-a456-2b19400b1771",
+          "_name": "Unflappable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "58252d39-c427-5e3e-b2ba-6b88606f6407",
+          "_name": "Judoka Skill"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b78dfdd3-106f-558f-a6a9-38509e8193fe",
+          "_name": "Preemptive Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "09656de1-2f61-51c2-8acd-2baa0dc79f58",
+          "_name": "Not Today!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9693263f-2994-552a-9467-683b99215b53",
+          "_name": "Defensive Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "157b8ada-5b5d-53d2-990c-05065f9b311e",
+          "_name": "Moira MacTaggert"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "48799fb9-fb5a-5819-8a8e-9e64a1ceb7da",
+          "_name": "X-Gene"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c31521fd-7968-5fba-8adf-9a2f8c4be001",
+          "_name": "Beauty and the Thief"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "33913ba8-022b-59ef-9c2f-fb43dbbdcb6e",
+          "_name": "Deadly Touch"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "147bc502-92fc-5a36-9720-b1aad5f6ed5e",
+          "_name": "Mystique"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "654de6d8-a651-5d81-8a03-a13584a0285e",
+          "_name": "Mystique's Manipulations"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "b5d22aa7-42b1-567a-8364-65bce1c1b6f9",
+          "_name": "Misled"
+        }
+      ]
+    },
+    "Rogue Nemesis": {
+      "label": "Rogue Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "147bc502-92fc-5a36-9720-b1aad5f6ed5e",
+          "_name": "Mystique"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "654de6d8-a651-5d81-8a03-a13584a0285e",
+          "_name": "Mystique's Manipulations"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "b5d22aa7-42b1-567a-8364-65bce1c1b6f9",
+          "_name": "Misled"
+        }
+      ]
+    },
+    "Reavers": {
+      "label": "Reavers",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7d1718d9-fe23-5c99-9401-a1b286cf870f",
+          "_name": "Donald Pierce"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9ca8732b-1e31-58e9-88f7-3e88ee828bbb",
+          "_name": "Skullbuster"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "24bfc352-ba21-567f-b736-737ab27480b8",
+          "_name": "Bonebreaker"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7528024e-d976-5b85-b071-d42c6fa8fae0",
+          "_name": "Wade Cole"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "42cf3f7a-8661-57fa-aa74-1da64fb8d9bc",
+          "_name": "Murray Reese"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e1fe7959-afc1-522d-869b-f45871a37be1",
+          "_name": "The Reavers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c97c5279-a456-5d2e-88cb-21521837648a",
+          "_name": "Cybernetic Enhancements"
+        }
+      ]
+    },
+    "MaGog": {
+      "label": "MaGog",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3ee6b13e-8d68-54f8-8987-f74be48e3fe7",
+          "_name": "Jolt of Adrenaline"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c61a26d3-fb17-5ed6-9545-8bdaf87731f7",
+          "_name": "Surge of Aggression"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "74d8be9d-0162-5415-9e92-55aafbfabc85",
+          "_name": "Surprise Contender"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b1fba15c-295b-5bf1-86c5-687367998e99",
+          "_name": "Pump Up the Crowd"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c41a2f23-6062-5305-94e5-a2189d4f955b",
+          "_name": "Break a Leg"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0a1b8722-3d70-5c24-beb8-4ed81012dc16",
+          "_name": "Defend the Title"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e5b67d01-9c7c-5592-8bad-9c7eeb32f39b",
+          "_name": "Stage Fright"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "4e8aa2b5-0752-53fc-9f52-ec75312c00f3",
+          "_name": "MaGog"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "074a5e76-8583-5146-aa44-369349cd839a",
+          "_name": "Melee in the Mojo-seum"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89078bca-7983-5ba3-a83c-c5452f25f465",
+          "_name": "The Champion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "10578ce3-62a8-5efd-b543-bce3e2da7cf8",
+          "_name": "The Challengers"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Spiral": {
+      "label": "Spiral",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "44069243-d60f-5f10-aabf-a411166e6f0b",
+          "_name": "Spiral"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "e6ac4861-cdd7-5ded-b4ad-c31789867c79",
+          "_name": "Spiral"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "5c4da94e-8326-5a1a-b195-df3c74c8c341",
+          "_name": "Spiral"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "e95d664e-a187-50d2-98c4-d606a4141630",
+          "_name": "Across the Mojoverse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a012269a-3690-5bdf-93a1-bebd8c3f248d",
+          "_name": "The Search for Spiral"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "421734a4-2c4a-5f00-9b9f-c8ad3f19ccbd",
+          "_name": "Cornered!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5389c07c-84a0-5682-b9e2-154245620453",
+          "_name": "Spiral's Swords"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4a991700-c9b2-5f1e-ba2c-52a8d472c0c1",
+          "_name": "Erratic Teleportation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43bafcc0-f784-56be-b5fd-19874eb9f321",
+          "_name": "The Show Must Go On"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0ccdf3c6-7ed6-5eb0-9cd2-fa53e7b8079b",
+          "_name": "Well-Armed"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Mojo": {
+      "label": "Mojo",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "b1068545-f178-5296-b350-0a06a88b0414",
+          "_name": "Mojo"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f63e8628-118e-5a57-a1f6-8645442b6e25",
+          "_name": "Mojo"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "4ff906aa-0913-5576-b2ac-fb6514796f58",
+          "_name": "Mojo"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "23917dec-56af-5138-b518-cf8c4b455863",
+          "_name": "MojoMania"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e332aeb7-7678-51ed-b9b5-41416302dd5f",
+          "_name": "Wheel of Genres"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cf78b3cc-dc34-52bb-8f96-69b706a66779",
+          "_name": "Major Domo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "54110c0a-ed9f-5c31-929f-4bae730717af",
+          "_name": "Stinger Tail"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "45cf52b3-953f-50e8-b8f5-dbbbc0a15478",
+          "_name": "Supporting Actor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bfcf9032-a4f6-57e4-ac2f-6b77dafd7627",
+          "_name": "Paparazzi"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "80e800ad-25a8-5e76-912f-f11998499804",
+          "_name": "Undercover Mojo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c0fce56c-462f-55f3-a914-dd3efc54f029",
+          "_name": "Curtain Call"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b0f90489-8194-58d2-ae2d-157bf87a7a44",
+          "_name": "Director's Directions"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d1250c63-7afd-55ca-93b3-d22a5f138ade",
+          "_name": "Top Billing"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Crime": {
+      "label": "Crime",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "912499cd-80e4-5d8c-a25f-7366dc7721db",
+          "_name": "Dial M for Mojo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "210c6cdf-f056-5cbe-b704-6e9ce0f8f23c",
+          "_name": "Build the Case"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1f2cc325-93bd-543c-b993-bd3af65c0e73",
+          "_name": "Crime Scene Investigation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "46c6ae66-cfca-5a4c-b003-401574dbe8f7",
+          "_name": "Law & Order"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "aa0513cc-e765-5227-9885-b2c30d892add",
+          "_name": "Dragnet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "caa48790-e606-5a26-9bee-58c2a364fc48",
+          "_name": "\"Elementary, My Dear Mojo\""
+        }
+      ]
+    },
+    "Fantasy": {
+      "label": "Fantasy",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "96630e12-0487-5ddb-8fb0-24ab93fdcba4",
+          "_name": "A Game of Mojo's"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ae0c1de4-ecd8-5dc8-a685-325bfa6b74d5",
+          "_name": "Dragon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d51ecd93-666c-52d1-9c4e-fb1b944ea465",
+          "_name": "Goblin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8229148f-8f22-5c88-8596-307561b89431",
+          "_name": "Troll"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "595651cf-67eb-5108-9ffd-b7aba217a741",
+          "_name": "Fetch Quest"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "10a2b2ca-196f-5f78-a184-3ad39c370b11",
+          "_name": "Mana Drain"
+        }
+      ]
+    },
+    "Horror": {
+      "label": "Horror",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6e1c1589-66e8-567f-9079-991948008bc2",
+          "_name": "The Mojo Files"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "037edc1d-d0cc-5a52-8003-4e37fb89baa8",
+          "_name": "Bandolier of Stakes"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f7ae86f4-cc2d-5b91-8714-954fb4c26fad",
+          "_name": "Cultist"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e8bc7632-48e0-53f4-b709-f0a3f5705c25",
+          "_name": "The Kraken"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6a334e65-4934-5e2a-91fe-3ab8cb5a2f02",
+          "_name": "Vampire"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4f519429-af7f-55b4-8c4f-fa4499c44652",
+          "_name": "Werewolf Pack"
+        }
+      ]
+    },
+    "Sci-Fi": {
+      "label": "Sci-Fi",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "66394864-5e48-5b85-9b32-aed05a1ab0d5",
+          "_name": "Mojo Runner"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "23a755bb-d0c2-5f49-919e-314872c506d9",
+          "_name": "Avalanche 9.0"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3fb09edc-a59c-5cc2-984f-e08bed2a263b",
+          "_name": "Blob 3.14"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2a0fc4e7-4c64-5245-a81f-98a57a2ed1af",
+          "_name": "Magneto 2.6"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fb4352c1-6504-5cfe-9d32-98a21f69d120",
+          "_name": "Pyro 4.0"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d26190ef-4648-5eea-896e-198128d8f4d7",
+          "_name": "Toad 2.0"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1bb4edb9-d09e-5b34-93aa-ceb6f18dfc71",
+          "_name": "ICE-teroid M"
+        }
+      ]
+    },
+    "Sitcom": {
+      "label": "Sitcom",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2ea0c250-3980-56c1-a11f-66e06dd2d633",
+          "_name": "Mojo in the Middle"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8290f0f5-f616-5c20-9fe0-5b7976b62ab8",
+          "_name": "Family Matters"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4d97b584-1ca5-5007-95d0-4a07de687020",
+          "_name": "Growing Pains"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7178a7d2-e5d9-5235-a546-63508d514c8b",
+          "_name": "The Odd Couple"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "df2a898c-2aa9-5a01-8d83-0a8e889f2cf9",
+          "_name": "The One with the Breakup"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a3a15095-173b-5817-9e77-17454520e6a5",
+          "_name": "Watch Me Play"
+        }
+      ]
+    },
+    "Western": {
+      "label": "Western",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d2dc1986-39c1-5c5f-8bc9-7e239795fab1",
+          "_name": "Wild Wild Mojo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "570a0162-9ad3-5480-aa7c-777cfbe2a090",
+          "_name": "Dead or Alive"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3026c95b-d2f0-51b4-8551-50c9d88d9025",
+          "_name": "Card Shark"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1af5c64c-557f-5746-b596-5fa69683b178",
+          "_name": "Gunslinger"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "522863e2-a553-5746-a00a-a6d861b1787c",
+          "_name": "A Game of Cards"
+        }
+      ]
+    },
+    "Longshot": {
+      "label": "Longshot",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c2452433-13b5-57e9-a48e-ea883300cb2c",
+          "_name": "Longshot"
+        }
+      ]
+    },
+    "Cable": {
+      "label": "Cable",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "28ca336a-ea67-5219-a7f3-ccd355c746ac",
+          "_name": "Cable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "403b8f95-623c-5d69-9dd3-f9530e732a9c",
+          "_name": "Bodyslide"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7e21cedd-e15f-5459-8a6d-cf8418ac7ee3",
+          "_name": "Mind Scan"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ac8250aa-182c-5094-bf43-c32dc0185295",
+          "_name": "Precognition"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "b9704ccf-7892-5d67-8199-72d40a6d6f94",
+          "_name": "Telekinetic Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "59da2f93-b765-5828-bdd7-07f1ae409db2",
+          "_name": "Technovirus Purge"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "09156fa1-4caa-52fc-ba58-1435892cae99",
+          "_name": "Graymalkin"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "16d1bcf1-866d-5039-b352-5d637584619c",
+          "_name": "Professor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a1853e01-ab40-5b39-a7da-c993838e3467",
+          "_name": "Askani'son"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "266ecd7b-75f3-57f7-ad8c-775f0a373043",
+          "_name": "Forced Amnesia"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0240139c-a671-5d16-8d91-88938b57a8dd",
+          "_name": "Plasma Rifle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d0f6362d-28be-5a0e-85a0-1d2222815ccd",
+          "_name": "Telekinetic Force Field"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f963776e-5838-517f-b366-333dd6606fcc",
+          "_name": "Temporal Leap"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b5f61707-32f7-564a-8bdb-a166fe351086",
+          "_name": "Caliban"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5cd47177-9e7e-5c2f-a453-52f9b1194d9f",
+          "_name": "Fantomex"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bb72d3f6-8552-5253-9172-5b86f2fc80c8",
+          "_name": "Sunspot"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "3ffe2523-d96a-5639-ac3e-3548049b57d8",
+          "_name": "Mission Planning"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f42a3fb7-aa99-57b8-b588-55af78d43c06",
+          "_name": "Call for Backup"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6b98452e-0275-5e56-9069-8e4e464388ea",
+          "_name": "Lock and Load"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f0cad5ea-97fb-56f1-b340-064d0d747c72",
+          "_name": "Establish Perimeter"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "73064326-bdb6-5585-9fdb-a88d561f28a5",
+          "_name": "E.V.A."
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6576dca8-dbda-5da8-833c-2ef243f2fe22",
+          "_name": "Uncanny X-Force"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "56730c20-fee3-5e28-97f0-32df77d10ec3",
+          "_name": "Mission Leader"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cf6d4d1b-15c2-5fbe-9433-b9d03e17d104",
+          "_name": "Deadpool"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8d3f99ea-cf39-578e-be48-c11e93382242",
+          "_name": "Deathlok"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7093dbb0-6496-50fe-8511-21af212499d6",
+          "_name": "Frenemies"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ba868602-930c-5dba-bffa-0473f79886e1",
+          "_name": "Build Support"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a742d619-03a3-534d-94ac-3aac48f656ac",
+          "_name": "The Power of the Mind"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2ad87be3-e5bb-5190-a9de-4ae141eaa19a",
+          "_name": "Psimitar"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "61c8ac7d-691a-533b-a61a-ea438acb4d83",
+          "_name": "Sidearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8fff4cad-b621-5986-95cc-49c9ce8c9009",
+          "_name": "Technovirus Resurgence"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "90fad8cf-092e-557d-974c-6e4e55b64cd5",
+          "_name": "Stryfe"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8f9e0e0b-4b1c-51f2-ba4e-63f22224001f",
+          "_name": "Back to the Future"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f0393598-514a-57ef-80c9-a1e4417adb56",
+          "_name": "Telekinetic Force Field"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9177ed8a-f99f-57f0-b6a5-3cdc4fd6e6e8",
+          "_name": "Mind Scan"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "33059b17-96a0-5fd8-a618-421d53d0fed3",
+          "_name": "Telekinetic Blast"
+        }
+      ]
+    },
+    "Cable Nemesis": {
+      "label": "Cable Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "90fad8cf-092e-557d-974c-6e4e55b64cd5",
+          "_name": "Stryfe"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8f9e0e0b-4b1c-51f2-ba4e-63f22224001f",
+          "_name": "Back to the Future"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f0393598-514a-57ef-80c9-a1e4417adb56",
+          "_name": "Telekinetic Force Field"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9177ed8a-f99f-57f0-b6a5-3cdc4fd6e6e8",
+          "_name": "Mind Scan"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "33059b17-96a0-5fd8-a618-421d53d0fed3",
+          "_name": "Telekinetic Blast"
+        }
+      ]
+    },
+    "Domino": {
+      "label": "Domino",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "c2d3ef03-5414-5911-97ed-f9ae976b82ce",
+          "_name": "Domino"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "79f3e967-48a7-5f09-a8e3-8198b6bda16d",
+          "_name": "Diamondback"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "95bd43de-91d9-5dc8-9ff3-897a2aca6b49",
+          "_name": "Outlaw"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "09e26a46-7eb8-548b-b590-dfe41c73b138",
+          "_name": "A Good Workout"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6e5d652f-f90c-557a-b3fa-6e3a28e7fc2d",
+          "_name": "Luck Be a Lady"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "bc7912ba-f649-537c-80f8-8102ea6edbdc",
+          "_name": "Right Place, Right Time"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "588fffb7-0740-5229-8958-660d3da6eb02",
+          "_name": "Jackpot!"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "fb994bcf-5b5f-565f-a2ee-d134483544d7",
+          "_name": "Pip the Pug"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5aa7a758-1f67-5e57-92e8-306c04fb4736",
+          "_name": "The Painted Lady"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ac3b23fa-5ef2-5b4b-9601-6d7fc779c5a8",
+          "_name": "Domino's Pistol"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "91f3be33-119a-55df-b67e-c74cc3b295dd",
+          "_name": "Lucky and Good"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ea3fbe44-4523-5d7d-9d9e-820f52b4d45c",
+          "_name": "Lucky Break"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "75784aa0-b63c-5e76-8a93-0334c47d7a8a",
+          "_name": "Probability Field"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1aec1633-1b08-524b-9617-de04ab06ef6a",
+          "_name": "Feral"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "174b8a65-e26d-584f-95aa-72190aacbc7f",
+          "_name": "Wolfsbane"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2031e243-bde1-5192-9397-d7a2962ada0f",
+          "_name": "Even the Odds"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "385d56f8-c6b2-599d-a692-ff592250a372",
+          "_name": "Team Investigation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c49b447f-7e88-5152-8990-ad8ec20952fa",
+          "_name": "Take Out the Guards"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "f59664a1-2166-50d2-8c41-580ebb5dae4b",
+          "_name": "Overwatch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "740dd478-01b5-5a53-83e4-c57f49b57253",
+          "_name": "Atlas Bear"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0673d5c8-b543-5c44-a1af-490d68b1dc75",
+          "_name": "White Fox"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0a663351-0d82-5d2e-b8cf-ebbe2e503c94",
+          "_name": "The Posse"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4238dd1d-9edf-50aa-beab-4bc16320ac27",
+          "_name": "Superpower Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "ce8a1d63-7d54-52a7-b43c-d4ca9150962f",
+          "_name": "Digging Deep"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "82ae7b80-18dc-56b3-8ee7-270395054e16",
+          "_name": "Sharpshooter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0db2034d-fccb-5cc2-8758-94fcb6044e44",
+          "_name": "Memories of Armageddon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "465d6036-80fb-5c2d-84d2-621baec1356a",
+          "_name": "Topaz"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8f5cfc57-1c19-5415-98f5-65cd7c16786f",
+          "_name": "Not My Lucky Day"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1d26179a-b37e-5248-b586-0a4e553a548a",
+          "_name": "Prototype"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "19eb5273-4d1d-58b6-bab1-6553a8ada5e7",
+          "_name": "Superpower Feedback"
+        }
+      ]
+    },
+    "Domino Nemesis": {
+      "label": "Domino Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "465d6036-80fb-5c2d-84d2-621baec1356a",
+          "_name": "Topaz"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8f5cfc57-1c19-5415-98f5-65cd7c16786f",
+          "_name": "Not My Lucky Day"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1d26179a-b37e-5248-b586-0a4e553a548a",
+          "_name": "Prototype"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "19eb5273-4d1d-58b6-bab1-6553a8ada5e7",
+          "_name": "Superpower Feedback"
+        }
+      ]
+    },
+    "Prelates": {
+      "label": "Prelates",
+      "cards": []
+    },
+    "Morlock Siege": {
+      "label": "Morlock Siege",
+      "cards": [
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "9a8876f1-7a00-598b-a636-114f18e6bc68",
+          "_name": "Knock, Knock"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "c6b96ba2-9592-58fe-b914-5078a47cc96d",
+          "_name": "Mutant Massacre"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "80801cb6-b122-54c0-ad81-be11b67037f0",
+          "_name": "Morlock"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dd1a46cc-2e27-512e-89e8-f205d3a9de42",
+          "_name": "Hide!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "90f790ad-16f7-5297-a6b1-cfb30423fb8e",
+          "_name": "Routed"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9afc193d-b202-5cbd-9f8f-c00b0992fc23",
+          "_name": "Bolstered by Wrath"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ec1b3b6c-cc27-5b78-9c5a-39084ccbdb52",
+          "_name": "Pushed to the Limit"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db41efb0-214a-5638-b2d8-f456101cfe6f",
+          "_name": "By Any Means"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "430b63c5-1602-5a13-80c8-4c974d7a019b",
+          "_name": "In the Midst of Chaos"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "478a892b-6e7b-5c9b-8738-c64f12be1a36",
+          "_name": "Maraudin' Ain't Easy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "09978893-5779-5eb2-a5c2-d246a7939dd7",
+          "_name": "Territorial Control"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "206dd824-8ce4-5680-8b36-99de05446b90",
+          "_name": "Back in Action"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "c47fe634-7f9a-5c75-a2c9-6d70c6add403",
+          "_name": "Seek the Weak"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d8c96579-6f06-5070-a2c6-2aa125a3e483",
+          "_name": "Arclight"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f825892b-bb54-5ecd-a45b-3ff73ff6c2a4",
+          "_name": "Blockbuster"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "a44d2646-97f5-5276-8306-f150627f288b",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "45437d7b-3768-5e38-b02c-a361d2dc6e13",
+          "_name": "Greycrow"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "4f17a668-2332-56e5-b2aa-28276083f515",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "95a7f9c7-8389-5faf-8a4e-e6cf00cddf51",
+          "_name": "Riptide"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "9bddac86-7e8b-56e3-997a-da26f181fd24",
+          "_name": "Vertigo"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Morlock Siege"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "ACTION_LIST",
+          "multipleDoubleSidedVillains"
+        ]
+      ]
+    },
+    "Military Grade": {
+      "label": "Military Grade",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "74e73f86-5ffd-5480-91fc-833f757d5a02",
+          "_name": "Heavy Armament"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fab801bd-2b0b-5970-8c34-c1da09fdfb57",
+          "_name": "Titanium Exoskeleton"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "01c50f0f-e616-568a-bb07-8db3dd5f280e",
+          "_name": "Inhibitor Collar"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "45491b68-5c19-572b-9155-680b0f0012d9",
+          "_name": "The Senator's Support"
+        }
+      ]
+    },
+    "Mutant Slayers": {
+      "label": "Mutant Slayers",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2b5020bb-12ab-5428-bd78-1c609378e8ea",
+          "_name": "Vertigo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adc7631f-1955-51d7-bc87-85b811f97fe1",
+          "_name": "Mutant Slayers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "48e4b9cb-c160-5fd6-925e-0b43ef5ae6b7",
+          "_name": "Bound by Business"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0b5ee34-867f-53fd-8905-5d00b6c331e7",
+          "_name": "Arclight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "998f2ab6-0aca-5519-9fb6-5b0cc9427e4d",
+          "_name": "Blockbuster"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bde99f9e-1c71-5a7e-99ca-dbbfaa306063",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2a5b5c36-f6fd-5d06-9513-6e7fee1a3f89",
+          "_name": "Greycrow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5a0b2bf6-c83f-5d84-93a8-63157e7c9940",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "84f643ee-8378-53b5-9307-adcc0477510d",
+          "_name": "Riptide"
+        }
+      ]
+    },
+    "On the Run": {
+      "label": "On the Run",
+      "cards": [
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "459a3fb1-de6c-5535-bdee-01b11917059f",
+          "_name": "Gotta Get Away"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "c41e3ced-5829-5940-b60b-096fd7b2f3a5",
+          "_name": "Escaping with Hope"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e036bd9b-bbba-510c-9f8a-fb35f6ca18af",
+          "_name": "Hope's Captor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "643227d6-1cf4-5c07-97b2-37595e185e35",
+          "_name": "Hidden in the Clutter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "39a6de19-bc18-54dd-b874-d971ea1075f4",
+          "_name": "Favored Weapon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b3f4c4d9-5c6b-59d1-999b-5ad51bf5e77f",
+          "_name": "Bushwhack"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "67cd6fbd-d527-5eca-bc7b-7ae24547b63f",
+          "_name": "Pure Force"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fa7b1912-b31f-5d37-ba29-28c0e997e696",
+          "_name": "Dizzying Deeds"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "05cab1df-8971-55cd-8e84-25d2c19909bb",
+          "_name": "Tag Team"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d8c96579-6f06-5070-a2c6-2aa125a3e483",
+          "_name": "Arclight"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "f825892b-bb54-5ecd-a45b-3ff73ff6c2a4",
+          "_name": "Blockbuster"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "a44d2646-97f5-5276-8306-f150627f288b",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "45437d7b-3768-5e38-b02c-a361d2dc6e13",
+          "_name": "Greycrow"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "4f17a668-2332-56e5-b2aa-28276083f515",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "95a7f9c7-8389-5faf-8a4e-e6cf00cddf51",
+          "_name": "Riptide"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "9bddac86-7e8b-56e3-997a-da26f181fd24",
+          "_name": "Vertigo"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "On the Run"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "On the Run"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ],
+        [
+          "ACTION_LIST",
+          "multipleDoubleSidedVillains"
+        ]
+      ]
+    },
+    "Nasty Boys": {
+      "label": "Nasty Boys",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "179437f1-cad5-5f1b-99ad-839990360ad9",
+          "_name": "Gorgeous George"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "06e9e32e-05aa-54f8-a5a9-df905c45b84d",
+          "_name": "Hairbag"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b4d6664b-49b6-54f3-9861-e786a0a17b20",
+          "_name": "Ramrod"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bce1764b-24f4-592f-bcf5-df09b9fca8ec",
+          "_name": "Ruckus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b0363323-936a-53b5-8ea7-a8f91e28796e",
+          "_name": "Slab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db2acc5f-f8ac-5503-8005-862a1f0e5f3e",
+          "_name": "Get Nasty"
+        }
+      ]
+    },
+    "Juggernaut": {
+      "label": "Juggernaut",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "b6e2ce04-af54-57cd-b0a6-01a1127a3781",
+          "_name": "Juggernaut"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "74b1aec5-a33a-5618-8dd3-f8075741107b",
+          "_name": "Juggernaut"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "efdafa79-37cb-539b-93c9-7c4572785e1b",
+          "_name": "Juggernaut"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "cfdaaf11-c7fb-5cf8-875c-bc6238342672",
+          "_name": "The Unstoppable Juggernaut"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cfe0579c-4c74-55c7-a1a4-c53eca37f1dd",
+          "_name": "Juggernaut's Helmet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "045ea9bd-b68f-5d32-a4b3-8e001185b07a",
+          "_name": "Head of Steam"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "26a2ffa6-6868-5395-973a-193547670df5",
+          "_name": "Building Momentum"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2f87c5e7-5d38-5f9d-b7ae-b53b3a490bed",
+          "_name": "Breakthrough"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4ad9c8dd-2ebe-52e5-a0a7-d85d1f753293",
+          "_name": "Flatten"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "33dc3793-a903-5964-86f1-da924e672507",
+          "_name": "Ground Pound"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4d8518a4-ee0f-5a1c-99aa-8c930e77851b",
+          "_name": "Trample"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "47ac81ee-e747-5239-869b-baabefa35363",
+          "_name": "Cyttorak's Exemplar"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Juggernaut"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Juggernaut"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Hope Summers": {
+      "label": "Hope Summers",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e9d08f29-af52-590d-bc2c-37498c3fc919",
+          "_name": "Hope Summers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4d43d2da-ad2e-5377-b374-504644255c0a",
+          "_name": "Captive Hope"
+        }
+      ]
+    },
+    "Black Tom Cassidy": {
+      "label": "Black Tom Cassidy",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f0c10124-b3c9-57ea-b224-563a5bbd834c",
+          "_name": "Black Tom Cassidy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "413cf921-f4da-52ac-b193-dd369555a4a6",
+          "_name": "Creeping Willow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cb2becaf-6310-5e56-ade1-3e3f27a706d9",
+          "_name": "Making Green"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3dca8b6e-c5ad-511d-86e6-a33efa56ff31",
+          "_name": "A Sound Thrashing"
+        }
+      ]
+    },
+    "Mister Sinister": {
+      "label": "Mister Sinister",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d457d140-9b41-5133-9f73-4ce4a5633fda",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "94cede44-0f3b-58b3-844e-9428ba85778f",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "a82d6e39-1cef-5f65-b1ac-e8b0db8e6f2b",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "cd9b6443-ff3c-548a-8109-bec3e522d8e8",
+          "_name": "Sinister Intent"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "370fbcfa-acca-5a2b-8f24-693692f0d75d",
+          "_name": "Sinister Experiment"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "d052c376-a65b-5121-8b1e-5ba6d1707f9e",
+          "_name": "Sinister Experiment"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "d06fe4b8-1dfa-5a34-917d-0080cc1510da",
+          "_name": "Sinister Experiment"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "6ab3193d-15d6-5910-9ba5-ffdda2605f2e",
+          "_name": "Sinister Ends"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "28dec4dd-0225-58c8-b1a2-8353d092c1ab",
+          "_name": "Sinister Disguise"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f38caa17-d921-5bec-bf88-16cc6b196809",
+          "_name": "Sinister Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f7c2314b-f794-539e-bba5-15761d042b24",
+          "_name": "Teleported Away"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5ac846a5-9ff0-565a-b1fd-bdb7b33aab62",
+          "_name": "Genetic Mastery"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a813e482-3257-5eb8-bcde-e8873240caac",
+          "_name": "Molecular Control"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "17da7c53-dd65-55ba-85f3-cc4dda3a9328",
+          "_name": "Sinister Schemes"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e3f5dfae-2f38-518d-abb3-8b38abffc7c0",
+          "_name": "Sinister Strike"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Mister Sinister"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Mister Sinister"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Flight": {
+      "label": "Flight",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4e336ee6-33cb-571f-9e5d-3087dc93a971",
+          "_name": "Flight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6699829e-96d8-5cce-bc1e-ca3b1b0febdf",
+          "_name": "Aerial Bombardment"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f5174ac-7ac5-57cd-89f0-15bbf1932dd1",
+          "_name": "Out of Reach"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "764273b6-b004-557f-85fc-26799f54697b",
+          "_name": "High Ground"
+        }
+      ]
+    },
+    "Super Strength": {
+      "label": "Super Strength",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a3f46fd8-5e1e-5009-b180-9156bf2b98c6",
+          "_name": "Super Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "84b1591a-0388-5bd1-b590-177d0c9a2bee",
+          "_name": "Impervious"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6cb93cb7-f0ec-58aa-9bfb-17f68be67feb",
+          "_name": "Thrown Oject"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b0f9f2a3-6842-5a33-a0ae-fa042e0e4445",
+          "_name": "\"I'll Take That\""
+        }
+      ]
+    },
+    "Telepathy": {
+      "label": "Telepathy",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9579ef5b-1a1d-5e8e-b868-fc3fc704423b",
+          "_name": "Telepathy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5812391b-2f8a-5258-a267-dc897bce1f87",
+          "_name": "Manufactured Drama"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c849cfc8-256c-5818-8210-1d13f298da1a",
+          "_name": "Sowing Discord"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "74f84e31-9d5b-5767-9ca3-a69a14a319eb",
+          "_name": "One Step Ahead"
+        }
+      ]
+    },
+    "Stryfe": {
+      "label": "Stryfe",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "5a209714-80ee-5390-b1e2-96c5689e5b10",
+          "_name": "Stryfe"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "683b7bf3-6edb-50f5-a48e-1330e7339ef1",
+          "_name": "Stryfe"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "8936e362-559b-524b-866c-6724a7b0369f",
+          "_name": "Stryfe"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "a6629a57-2a13-58bb-b5f1-47f6c7973c76",
+          "_name": "Uncontrollable Power"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "b99d2385-a1af-5c20-8cba-4f23357ad766",
+          "_name": "Left to Your Fate"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2d635edb-9cf2-5af2-bfbd-951756024a76",
+          "_name": "Stryfe's Grasp"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9258606e-d82f-5701-bcd2-44560f3f6607",
+          "_name": "Mental Transferal"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b7f8827f-4521-5132-a60c-7f780017b946",
+          "_name": "Mind Alteration"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "544a3ee1-cced-5228-83db-516128c53646",
+          "_name": "Mind Trap"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d563a1c1-22ab-5065-a3a9-1a73f8d24665",
+          "_name": "Psionic Amnesia"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3e1a73a2-49e5-5c7c-b646-c6c97adb3c7e",
+          "_name": "Psychic Inertia"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e07334be-6c82-5bcb-863a-de69704fb86b",
+          "_name": "Zero"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c1816dd1-6ee0-5f60-b32f-1381012c0c86",
+          "_name": "Cerebral Erasure"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "587e4577-044e-547e-a6af-ca7c215f04b7",
+          "_name": "Telepathic Camouflage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "edcc483e-cfd8-5227-a688-b48777f8cde9",
+          "_name": "Psionic Surge"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d4ded6b3-a87d-5029-bb4e-d0c4b2e426aa",
+          "_name": "Psychic Override"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "01bb6d28-f0bb-5cc9-bf10-017c75ba8472",
+          "_name": "Telekinetic Wave"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Stryfe"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Stryfe"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Extreme Measures": {
+      "label": "Extreme Measures",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fa1f359e-95b8-576d-9a46-7bbeeac489b5",
+          "_name": "Strobe"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "75d695cd-cb18-580d-a3fe-96cb63cd2e99",
+          "_name": "Tempo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3eb0a9a5-ab1f-51a7-891f-a8c9bced3ae6",
+          "_name": "Thumbelina"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "969c0d52-72ab-5610-b582-70e5eb0d3418",
+          "_name": "Wildside"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43278d54-1d0a-55fb-b927-8881da20df9b",
+          "_name": "Extreme Measures"
+        }
+      ]
+    },
+    "Mutant Insurrection": {
+      "label": "Mutant Insurrection",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "029572a6-3e52-5d9e-ab46-69326854cb83",
+          "_name": "Dragoness"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bb730ae3-a59c-5eb5-bd9d-d35eb33e5379",
+          "_name": "Forearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adc3c28b-e016-54cb-a55e-4986d9bf9028",
+          "_name": "Reaper"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9236c1ad-5aca-5dd8-91d8-7061097abb64",
+          "_name": "Samurai"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7aebe1c1-c9b3-55fc-ab1a-a712e72e3b04",
+          "_name": "Mutant Insurrection"
+        }
+      ]
+    },
+    "Campaign (NeXt Evolution)": {
+      "label": "Campaign (NeXt Evolution)",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "79ecce41-3315-58df-af03-b96e53de92ec",
+          "_name": "Assemble the Team"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "95f6ada7-b3c0-55e9-bf3f-7e027daac923",
+          "_name": "Establish Safehouse"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "94737dc0-bd11-5624-a73b-f63ee63f776a",
+          "_name": "Gear Up"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6a85c827-e32c-5644-bc9b-ad378e5b75aa",
+          "_name": "Mission Prep"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "553efeef-76cb-57a1-a26c-a8e862ef8811",
+          "_name": "Practice Maneuvers"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "145b4051-76eb-59a1-baee-d449caf45dfc",
+          "_name": "Prepare Defenses"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 4,
+          "databaseId": "68db6785-b79e-5ee9-b652-3e1bf82d83f1",
+          "_name": "Pouches"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "6ce297ce-c16a-5f64-923e-9370ef77e66e",
+          "_name": "Safehouse"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1e26a0cd-1143-5d63-9ebb-322ec62b2d59",
+          "_name": "Lady Mastermind"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "a59d9a1d-e05e-55c0-8485-a77f8c1eb80a",
+          "_name": "Malice"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "697e0acc-0029-525f-84f6-c50577ce57e5",
+          "_name": "Scrambler"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "b59ff4f2-6c4b-52cc-afe0-e3b8488fe831",
+          "_name": "Vanisher"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "574028e3-5b93-559a-bdff-509a36cd9f9a",
+          "_name": "Under Pressure"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "978ce56c-d7ad-51f4-9c5f-02e605560a3f",
+          "_name": "Overburdened"
+        }
+      ]
+    },
+    "Psylocke": {
+      "label": "Psylocke",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "56c0d212-0279-5e87-94f2-f015b4621342",
+          "_name": "Psylocke"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 2,
+          "databaseId": "09196417-d8e6-5f4f-a42b-eb2cd9b7fb14",
+          "_name": "Psi-Knife"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "17cd5cd5-60ef-5d54-a3a0-72179d9f5fe2",
+          "_name": "Angel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "fce01864-f9c9-5c8e-8dac-0213b03718d6",
+          "_name": "Flurry of Blades"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "6a33a878-e573-569e-9643-0acc38ffd0bb",
+          "_name": "Mental Detection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ca72d794-ba7e-55d2-9176-910719889670",
+          "_name": "Psionic Redirect"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "852a98f8-2d8d-5dd7-8863-79d523a4f3d3",
+          "_name": "Telepathic Suggestion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3237b3c7-ff1c-5f05-b61d-a19f3ca7ce5d",
+          "_name": "Training Regimen"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f6c7dc8c-8075-5e02-aae2-c5311cf09e3e",
+          "_name": "Martial Arts Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d143be74-8ce0-5554-b1a6-1fb95a069f4f",
+          "_name": "Psionic Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7b85ba64-7ded-5d87-9710-9a21b199271e",
+          "_name": "Weapons Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8c375992-31b2-5f2a-8753-2b5ff1447ae4",
+          "_name": "Captain Britain"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f4402fd4-e1a3-5823-b7c4-58c4922529c7",
+          "_name": "Cypher"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "3043be3d-484b-5a66-b50a-70638e1109e7",
+          "_name": "Concussive Blow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8b32ec5b-0648-578e-b9b1-159a9702dada",
+          "_name": "Upside the Head"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "02022d5e-beb7-5e59-a0e8-64c6b10820f9",
+          "_name": "Lay the Trap"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "c5e3567a-78ad-572b-b828-a5b7b32dc136",
+          "_name": "Float Like a Butterfly"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "15f29d55-74b9-5060-bd2d-b60e368e7c6a",
+          "_name": "Pete Wisdom"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "cfe4a0cb-99c1-5eaa-81e9-88eebfa4f47d",
+          "_name": "Directed Force"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0818d67c-3acc-5a98-b160-d4ae9cc039ef",
+          "_name": "Soaring Hearts"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "a742d619-03a3-534d-94ac-3aac48f656ac",
+          "_name": "The Power of the Mind"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "493067e6-9b14-58d4-ab9e-7000e7695791",
+          "_name": "IPAC"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ef59daf8-98c5-5f53-ab51-1d0f7953287e",
+          "_name": "X-Bunker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "328aa42c-432d-503d-b782-a2d5a91419c5",
+          "_name": "Telepathy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12504bf5-96bc-58c8-b35e-ec45704fe9a1",
+          "_name": "Body Swapped"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "04e36b35-eea5-576d-aa95-3a4806f072ec",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "49772c93-55a3-5285-b5a2-6b25b69610cd",
+          "_name": "Interdimensional Plunder"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "02413aa1-9fde-5a00-b773-ed4e74a9e695",
+          "_name": "Psionic Illusion"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "38901ca1-98c4-5879-b6d4-d2c7d32d170a",
+          "_name": "Telekinetic Dragon"
+        }
+      ]
+    },
+    "Psylocke Nemesis": {
+      "label": "Psylocke Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "04e36b35-eea5-576d-aa95-3a4806f072ec",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "49772c93-55a3-5285-b5a2-6b25b69610cd",
+          "_name": "Interdimensional Plunder"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "02413aa1-9fde-5a00-b773-ed4e74a9e695",
+          "_name": "Psionic Illusion"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "38901ca1-98c4-5879-b6d4-d2c7d32d170a",
+          "_name": "Telekinetic Dragon"
+        }
+      ]
+    },
+    "Angel": {
+      "label": "Angel",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "c3a410de-2939-5255-9ea1-cdb9e71f07d7",
+          "_name": "Angel"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a59cf1ff-e06f-5258-bf89-7f2908df5e72",
+          "_name": "Psylocke"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "23524ef4-02c0-53e9-bf11-334bd6350833",
+          "_name": "Adaptive Plumage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "2ef2a153-12c5-5995-b74f-5cec879f9251",
+          "_name": "Aerial Agility"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "67971fd6-da20-5d1c-a04f-3c6c587ca738",
+          "_name": "Metamorphosis"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "0e9a9175-c622-56df-ae3f-6eba26891c7f",
+          "_name": "Natural Flight"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "c27fe1b4-958e-5d49-916e-f164d333d475",
+          "_name": "Razor Dive"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "aecc51e1-8f59-54ae-8d4d-471655182b3d",
+          "_name": "Avian Anatomy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "08c1a8f8-0187-5a7f-b3ed-94b42f9de3d4",
+          "_name": "Worthington Industries"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9de051d5-e575-5600-9644-14f5f4233bc0",
+          "_name": "Techno-Organic Wings"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "dbf4bf19-c6ff-5c08-a46b-56fb4f27e2b0",
+          "_name": "Elixir"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "55ab4a68-6cc9-51d1-93b8-19b01fa4fffa",
+          "_name": "Siryn"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "341cdb7f-9754-5e13-b926-8cdb8a97da32",
+          "_name": "Warpath"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "83afacaa-4d23-54d6-a1dd-78e1eb3cd40d",
+          "_name": "Aerial Intervention"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "463bde2d-c19e-500e-8509-7a658a2838d6",
+          "_name": "Ever Vigilant"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "944797ac-5515-5bc3-9df6-820206985461",
+          "_name": "Taunt"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "609ba2f4-5be3-5057-a3c1-f6e4b1497a12",
+          "_name": "Render Medical Aid"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "8ebfd76a-7f7b-51e4-b229-c149a9196ab0",
+          "_name": "Angel's Aerie"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "0206f4bd-e5d7-5bf5-9dca-965752903789",
+          "_name": "Containment Strategy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "def8c251-1d1a-5530-8283-7c73a716667f",
+          "_name": "Cannonball"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0818d67c-3acc-5a98-b160-d4ae9cc039ef",
+          "_name": "Soaring Hearts"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b129c8d8-dd7b-5eaf-bd6c-b11d204029da",
+          "_name": "The Power of Flight"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "3ca51a1a-9043-5240-bf42-2f7b7bc67091",
+          "_name": "Soaring Acrobatics"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e5ce8ddc-f51d-579c-aa70-1d202859ad27",
+          "_name": "Apocalyptic Influence"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e8b827d-9c4c-58e6-bbfe-7653ebb50d48",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "546e2387-ac0a-5bdd-a1fc-e34a36016c9b",
+          "_name": "Hook, Line, and Sinker"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2533c75a-3e8f-58c0-8690-c5df47d1c68a",
+          "_name": "Harpoon's Harpoon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0c787957-e8c6-55da-a410-82ba0cf9a003",
+          "_name": "Spear Shot"
+        }
+      ]
+    },
+    "Angel Nemesis": {
+      "label": "Angel Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e8b827d-9c4c-58e6-bbfe-7653ebb50d48",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "546e2387-ac0a-5bdd-a1fc-e34a36016c9b",
+          "_name": "Hook, Line, and Sinker"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2533c75a-3e8f-58c0-8690-c5df47d1c68a",
+          "_name": "Harpoon's Harpoon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0c787957-e8c6-55da-a410-82ba0cf9a003",
+          "_name": "Spear Shot"
+        }
+      ]
+    },
+    "X-23": {
+      "label": "X-23",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "c733c1df-cafd-5b1e-bec5-77d45d647b26",
+          "_name": "X-23"
+        },
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "5371b3fc-77db-5115-9b95-cb9fe6fa1462",
+          "_name": "X-23's Claws"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "aafcff7c-fba3-5893-b59c-b98785db7ba0",
+          "_name": "Honey Badger"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "14fec7e5-637d-5739-aaf3-c263064ccf6e",
+          "_name": "Animal Instinct"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "b58feaed-1520-550e-84dd-ae854a7fd465",
+          "_name": "Claw Mastery"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fea0ec4f-aaeb-5719-893b-871eb0337141",
+          "_name": "Regenerative Longevity"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f27e79a3-c742-5456-b7a8-075f7eeb1e13",
+          "_name": "Sisterly Bond"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2b89e228-1d09-515b-96cc-675685eb4d97",
+          "_name": "Sisterhood"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "bf554131-f5d4-5489-94c6-c826d231006f",
+          "_name": "Adamantium Lacing"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "654637e8-bdd2-5c9c-bb5b-9556000a86bc",
+          "_name": "Grim Resolve"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d0e1ab72-0380-5789-a7a7-e88ea3288c2c",
+          "_name": "Pain Tolerance"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "77d07b40-3e39-533f-8b6c-1298e551d9ff",
+          "_name": "Puncture Wound"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "615823a6-6650-5452-b4d3-72b36f6484d1",
+          "_name": "Boom Boom"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "2139b800-7282-52b2-983f-d560e433f8ec",
+          "_name": "Rictor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f5649629-177a-5ff2-ae2b-fa8056423cce",
+          "_name": "Shatterstar"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "44c9c2cc-8e21-57bb-815a-a585670f957f",
+          "_name": "Critical Hit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "222f0ed3-e80c-5b66-afaf-64f48c874fb3",
+          "_name": "Moment of Triumph"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "aaeb6c6a-e60f-5d5f-9d29-4db1372237af",
+          "_name": "Keep Them Busy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "8be59fac-57f5-5fd1-adcd-7bba840a89f2",
+          "_name": "\"Now I'm Mad\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e95eee5e-eda8-5fad-8011-d81d64c06c49",
+          "_name": "The Direct Approach"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "90a31753-4e68-57d6-8ddd-042b043ccc75",
+          "_name": "Specialized Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "493067e6-9b14-58d4-ab9e-7000e7695791",
+          "_name": "IPAC"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ef59daf8-98c5-5f53-ab51-1d0f7953287e",
+          "_name": "X-Bunker"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "9dea3718-60f9-5b5f-9a49-f692f21e819c",
+          "_name": "Endurance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c1e80964-526f-5515-8a6e-30c0cfef5953",
+          "_name": "Self-Isolation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4d19da80-db22-52e0-9241-abb18f3590f1",
+          "_name": "Lady Deathstrike"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7bf1f7ec-2c6b-5eec-882a-843b2b8cc044",
+          "_name": "In the Name of Vengeance"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c4bc6d31-2009-579b-9cca-cb90b34d5e1a",
+          "_name": "Cybermods"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "de21d2db-a5f8-5338-83ba-c8ed22c8178b",
+          "_name": "Critical Wound"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3176a069-83ed-530e-8dc7-d04bf846b8e2",
+          "_name": "Hack 'n' Slash"
+        }
+      ]
+    },
+    "X-23 Nemesis": {
+      "label": "X-23 Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4d19da80-db22-52e0-9241-abb18f3590f1",
+          "_name": "Lady Deathstrike"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7bf1f7ec-2c6b-5eec-882a-843b2b8cc044",
+          "_name": "In the Name of Vengeance"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c4bc6d31-2009-579b-9cca-cb90b34d5e1a",
+          "_name": "Cybermods"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "de21d2db-a5f8-5338-83ba-c8ed22c8178b",
+          "_name": "Critical Wound"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3176a069-83ed-530e-8dc7-d04bf846b8e2",
+          "_name": "Hack 'n' Slash"
+        }
+      ]
+    },
+    "Deadpool": {
+      "label": "Deadpool",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "39e02b25-fe3c-5530-8d5f-b4bb5674e99c",
+          "_name": "Deadpool"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "f641da33-f7af-53eb-9349-5ba659c2b29f",
+          "_name": "Cable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "4fb6b212-c03d-529d-9eb8-476deb19c43d",
+          "_name": "Exhausting Personality"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "9779b89c-fa50-5a83-bff2-4931170705c5",
+          "_name": "Maximum Effort"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c4693fbb-5426-5964-bd9f-00c3e1193b32",
+          "_name": "Metaknowledge"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "36848757-d86a-5baf-8199-6580ef5f8579",
+          "_name": "\"Yoo-Hoo!\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "332f2878-3598-5efb-b855-318b00b742d2",
+          "_name": "Montage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c91657c3-0f97-5cae-956b-889a8cb80c43",
+          "_name": "Chimichanga Truck"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "da6ad400-7503-5dd6-9715-9607f5b1ff04",
+          "_name": "Armed to the Teeth"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ea8302ab-e5ed-5e91-9ac6-ad87e5f1e719",
+          "_name": "Deadpool's Katana"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b0eb235f-b0a6-5f0d-9b08-5069654492fb",
+          "_name": "It Ain't Over..."
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "76da8579-4af2-5bea-8eeb-fae7b3c3d140",
+          "_name": "This Card is Fire"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b499ae8f-04c0-508a-ab45-cb455a3a9c54",
+          "_name": "Dogpool"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "c63652a3-e933-5779-9c5b-2aae037cefad",
+          "_name": "Headpool"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "dd2cf785-6c92-5147-af00-9984e664ab06",
+          "_name": "Kidpool"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b3378840-f012-570b-97cd-54b06c9872d2",
+          "_name": "Lady Deadpool"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "da94aa82-4485-5db2-a0fb-850ec24b420b",
+          "_name": "Barely a Scratch"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "553f3abf-8d32-5a27-9c88-27e16d1cfbc4",
+          "_name": "Cutupper"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "024531bd-7010-5545-a08e-582dec053a15",
+          "_name": "Da Bomb"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1d8a573e-240b-5d2a-ae30-95d6ff9bf312",
+          "_name": "Get Rage-y"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5937aa09-fb4b-5f78-940e-56cce5b0636a",
+          "_name": "\"I Got This\""
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5fdce7c1-aa9e-512d-ab63-85bb9b20de55",
+          "_name": "Not My Responsibility"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "73ee4d0f-9290-538c-a2f7-9ff1ebd2bccf",
+          "_name": "'Pool Inspection"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7d5ec696-709c-535d-a9b5-da3009d51c7b",
+          "_name": "Live Dangerously"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "ca893be3-5527-5bb1-9fc2-1fc3dd0c1250",
+          "_name": "Self Confidence"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0d489821-4372-5660-b542-cffb2b2c48a0",
+          "_name": "Self Control"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "008dd3dc-e908-5cb8-ac14-b9bb46af74cd",
+          "_name": "Self Preservation"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "99d3b4bf-13c4-5c82-959d-71e929fc0a36",
+          "_name": "Git Gud"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e2415d60-24fd-5596-ba01-ad7c5350a1c4",
+          "_name": "Healing Factor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "0250a249-c2b3-57d5-babd-2f84f45e0814",
+          "_name": "Stick-to-itiveness"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "7093dbb0-6496-50fe-8511-21af212499d6",
+          "_name": "Frenemies"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6092c310-46fb-5e7d-b6b6-166ffbd18f10",
+          "_name": "The Merc with the Mouth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6b51f1af-8313-5de4-aa4c-7f5541e85ad2",
+          "_name": "Butler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8ac08952-c2a2-5e95-9978-b02a475d3e25",
+          "_name": "Involuntary Procedures"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bb08f813-9731-5744-94de-34037fbc74d6",
+          "_name": "Tabula Rasa 16"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "4e3644eb-e202-5357-96be-6f1bb1fc933f",
+          "_name": "Mutated Soldier"
+        }
+      ]
+    },
+    "Deadpool Nemesis": {
+      "label": "Deadpool Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6b51f1af-8313-5de4-aa4c-7f5541e85ad2",
+          "_name": "Butler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8ac08952-c2a2-5e95-9978-b02a475d3e25",
+          "_name": "Involuntary Procedures"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bb08f813-9731-5744-94de-34037fbc74d6",
+          "_name": "Tabula Rasa 16"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "4e3644eb-e202-5357-96be-6f1bb1fc933f",
+          "_name": "Mutated Soldier"
+        }
+      ]
+    },
+    "Dreadpool": {
+      "label": "Dreadpool",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "193512d9-0a39-5965-8e6a-c2362a696e3d",
+          "_name": "Crisis of Infinite Deadpools"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2631bb66-465b-5d2b-aad6-3abf920f81e1",
+          "_name": "Dreadpool"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1ec6114b-db13-5e7a-afad-5e2b46ad8549",
+          "_name": "Dreadful Deeds"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ee7ec214-d090-5ecc-84a3-b0766e6c6260",
+          "_name": "Anti-Regeneration Ray"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "77d91181-44fa-5ce5-93fd-016323ba3b68",
+          "_name": "'Pool-ized"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "296b278f-ffb8-5a98-95cf-6f3f00d1b3c4",
+          "_name": "Metacidal Tendencies"
+        }
+      ]
+    },
+    "Bishop": {
+      "label": "Bishop",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "a1372b67-4108-5244-8eba-16ff3ae59534",
+          "_name": "Bishop"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "9d4bf77d-fb72-559c-bc5b-1b677dcc64f8",
+          "_name": "Malcom"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1e3d2540-f47c-5a4a-b566-2dd42e0761ab",
+          "_name": "Randall"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "b9f2ead4-dbd2-5bc7-ae71-53d394057f61",
+          "_name": "Bishop's Rifle"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "032a8a40-2539-58fa-815e-0573d1101647",
+          "_name": "Bishop's Uniform"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "13afcbbf-12d4-50ca-a432-5dc2a403c92d",
+          "_name": "Super-Charged"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "ea138a19-e1e3-5b55-8f45-615fb39930f6",
+          "_name": "Concussive Blast"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "862e96ba-e510-5dea-8fc8-abfa6cf79f35",
+          "_name": "Command Authority"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "0451337c-e1d5-5c7c-992b-8172c213d061",
+          "_name": "Energy Conversion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5f3f5387-b520-5789-aaa6-c1376368ddb4",
+          "_name": "Stored Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5cdb26c2-e888-5628-9cad-f69280794f71",
+          "_name": "Cable"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "63721cd6-aaf8-5fc9-ba46-6bf8efb34510",
+          "_name": "X-23"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "dd1e2956-9589-57ff-a1b2-a9e34e06f479",
+          "_name": "Team Training"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "646714ea-2c69-5786-98d9-a481dc0b57d4",
+          "_name": "Advanced Suit"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "db4a0b34-7931-582f-951b-85d1acaa9854",
+          "_name": "Sidekick"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "e84b16f6-d382-5c17-a321-7c8be6a619dd",
+          "_name": "Side-by-Side"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "4c869741-fd89-5b49-8d2d-4a7ec1ecd76b",
+          "_name": "Suit Up"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2da8638a-9879-5094-8d84-66e6b7692dd7",
+          "_name": "Lead from the Front"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "04fe3e79-279a-5d4b-93f4-bf6fa562e825",
+          "_name": "The Power of Leadership"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "374ad77f-cd52-5ddf-875a-94bd78307b13",
+          "_name": "Legion"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "d84f58d2-3f07-5670-bb25-dd3731a92292",
+          "_name": "Marrow"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "3150df04-a4db-5738-b03c-ed65cbfe87ae",
+          "_name": "Energy"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5e7c1b7e-64c2-5fd9-a0d6-dfcefcfe078d",
+          "_name": "Genius"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "e9fb6e46-2563-58cf-9f31-ca79d8e87228",
+          "_name": "Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3e261fbf-455c-57d8-98be-c665ff1691bf",
+          "_name": "Fear the Future"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2f7c82b3-437b-566c-96e4-fcadb7b587d6",
+          "_name": "Trevor Fitzroy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dd337ce4-c136-5e08-bd2f-55d4f35f4d70",
+          "_name": "Portal Through Time"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2bda35f9-bb46-5dca-9b3c-7432a6443cd3",
+          "_name": "Bantam"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "5f47fdc1-033a-50ca-b002-4dab223dc9ba",
+          "_name": "Temporal Trickery"
+        }
+      ]
+    },
+    "Bishop Nemesis": {
+      "label": "Bishop Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2f7c82b3-437b-566c-96e4-fcadb7b587d6",
+          "_name": "Trevor Fitzroy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dd337ce4-c136-5e08-bd2f-55d4f35f4d70",
+          "_name": "Portal Through Time"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2bda35f9-bb46-5dca-9b3c-7432a6443cd3",
+          "_name": "Bantam"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "5f47fdc1-033a-50ca-b002-4dab223dc9ba",
+          "_name": "Temporal Trickery"
+        }
+      ]
+    },
+    "Magik": {
+      "label": "Magik",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "2e5b27f1-7219-5f96-9f9e-fee182ac65f2",
+          "_name": "Magik"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5bb3b2df-6fba-5970-80e1-c14b08881b37",
+          "_name": "Colossus"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "471309eb-7520-5f65-b923-1fb7067447de",
+          "_name": "Limbo"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "6aae9c58-31db-5831-a998-f1ba69bc09c0",
+          "_name": "Magik's Crown"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "1998520d-9bf1-544f-93e5-56a27b64d7f9",
+          "_name": "Soulsword"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5858c44b-eed2-5b7a-8976-626fb639fc0c",
+          "_name": "Mystical Armor"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "cdfea9dd-51a0-5d25-a14d-5a69f52015c1",
+          "_name": "Scrying"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "90bc5cda-70f9-5b4d-af77-3f0e53c198ce",
+          "_name": "Stepping Disc"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "e9899909-dfff-574b-aaf9-32b782bb8ffd",
+          "_name": "Exorcism"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "20dd64a3-501a-586e-ada2-7f69ed9e179c",
+          "_name": "Soul Strike"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "97e3cc36-ea76-5a18-b67b-6142e10ec157",
+          "_name": "Magic Barrier"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "a76d9524-7de4-5a86-a82e-72fbb1818389",
+          "_name": "Goldballs"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "591e4469-a7bc-5763-81b4-b0f620c8e077",
+          "_name": "Tempus"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "0bd0aa74-772b-52d6-8550-e678f0d170eb",
+          "_name": "Blood Rage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "77e6c630-a3c9-5742-a23b-fbaad8a26b75",
+          "_name": "Test the Defense"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "7919e4ea-6a6b-53e2-ac09-455937446697",
+          "_name": "Full-Body Charge"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "d9ba57fb-c678-5559-9c5f-1d4101e68e35",
+          "_name": "Clobber"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 2,
+          "databaseId": "fa57c0e9-933f-539d-b32e-8ffa9214339c",
+          "_name": "The Power of Aggression"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "5a5174d6-8f77-57f1-a13f-1d95874504a7",
+          "_name": "Triage"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "872aaeaf-58b6-52f5-9dde-4556b7069ca9",
+          "_name": "Stepford Cuckoos"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 1,
+          "databaseId": "791873d6-d6cf-5f4b-8286-fd2beb9668e2",
+          "_name": "Bloodgem"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "2fd815b0-9aad-5da0-aa9e-3ad7e8c6e871",
+          "_name": "Basic Spell"
+        },
+        {
+          "loadGroupId": "playerNDeck",
+          "quantity": 3,
+          "databaseId": "5f838c37-3f9e-5b87-b7ed-2a1daba4e17c",
+          "_name": "Spiritual Meditation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fcd7e1b7-abc1-5a9b-b71b-1b30d0b76525",
+          "_name": "Darkchilde"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b39a7ed4-4520-596a-911c-1e584d85ca8b",
+          "_name": "Belasco"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0f51675-84b1-57d8-bd18-d5b1ea14a0c1",
+          "_name": "Ruler of Limbo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cef26124-5a22-5c2c-a0a3-c2bcc416a4e9",
+          "_name": "S'ym"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4480f6ee-d377-5df7-b528-6ff6b0e9af3e",
+          "_name": "Witchfire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3cca9390-d213-5c09-8366-ccb60621b4b7",
+          "_name": "Battle for Limbo"
+        }
+      ]
+    },
+    "Magik Nemesis": {
+      "label": "Magik Nemesis",
+      "cards": [
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b39a7ed4-4520-596a-911c-1e584d85ca8b",
+          "_name": "Belasco"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0f51675-84b1-57d8-bd18-d5b1ea14a0c1",
+          "_name": "Ruler of Limbo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cef26124-5a22-5c2c-a0a3-c2bcc416a4e9",
+          "_name": "S'ym"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4480f6ee-d377-5df7-b528-6ff6b0e9af3e",
+          "_name": "Witchfire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3cca9390-d213-5c09-8366-ccb60621b4b7",
+          "_name": "Battle for Limbo"
+        }
+      ]
+    },
+    "Unus": {
+      "label": "Unus",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "77c0171e-bca9-5bbc-a664-2ced667a2bf0",
+          "_name": "Unus"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "264cb2aa-0b04-5563-a41b-e4efe709b24a",
+          "_name": "Unus"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "406117d8-d4f8-53ef-909d-909b67297b90",
+          "_name": "Unus"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "0ea1ae1a-3d93-5d21-bbeb-717d10454599",
+          "_name": "Hunting Gene Traitors"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b1c8493a-9ab1-577c-8b63-7dec98991f4e",
+          "_name": "Prelate Sidearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "316a7b53-e336-540e-98b3-66cd3cd2e536",
+          "_name": "Prelate Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a070c546-cefd-50b9-a0a9-2f2f8f222a3e",
+          "_name": "Infinite Hunter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "aebc1e15-43d3-56b1-971f-18069d996485",
+          "_name": "Genetic Experiments"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "35b73009-ca5f-5e4d-9679-d362c9419d55",
+          "_name": "Infinite Prelate"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "142cba2d-d73f-5b70-baa0-53ab8cb2ee5e",
+          "_name": "Endless Ranks"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Unus"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Unus"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Infinites": {
+      "label": "Infinites",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9db49225-3bad-50dd-a8bc-ba23873a1b63",
+          "_name": "Infinite Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "aaf106a6-8751-55f0-916c-1ace93a1bb6c",
+          "_name": "Culling the Weak"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "01c842cb-66a5-55d0-bf3c-c0d7908fda97",
+          "_name": "Gene Pool"
+        }
+      ]
+    },
+    "Dystopian Nightmare": {
+      "label": "Dystopian Nightmare",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a74836c9-ef22-53b5-b9d3-85d7fe9d3042",
+          "_name": "Hunted"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fc418a6c-0b4d-5f12-a88e-959bccfc8fa7",
+          "_name": "War-Weary"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "94e0e1ce-8a9f-53d2-912c-8d3d8f454be4",
+          "_name": "Targeted for Extermination"
+        }
+      ]
+    },
+    "Standard III": {
+      "label": "Standard III",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b24e0dfc-f3fa-5815-a97c-2eebf7dd8cdf",
+          "_name": "Pursued by the Past"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3c8d20a1-056a-59ab-a061-281e0b590ff0",
+          "_name": "Dark Designs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "90cd6de6-684e-515d-a3e4-6767fdbf02bf",
+          "_name": "Sinister Strike"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "40e50919-40cc-5d06-b189-2bcd6a8e24d9",
+          "_name": "Evil Alliance"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "77d9571d-11da-5d51-8d80-a248c0dd2d76",
+          "_name": "Nowhere is Safe"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2988184e-172f-53d7-8845-5ca0b0b91654",
+          "_name": "Drawing Nearer"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "LOG",
+          "Setup: Reveal Pursued by the Past"
+        ],
+        [
+          "VAR",
+          "$ENV_CARD",
+          [
+            "ONE_CARD",
+            "$CARD",
+            [
+              "EQUAL",
+              "$CARD.databaseId",
+              "b24e0dfc-f3fa-5815-a97c-2eebf7dd8cdf"
+            ]
+          ]
+        ],
+        [
+          "MOVE_CARD",
+          "$ENV_CARD.id",
+          "sharedVillain",
+          -1
+        ]
+      ]
+    },
+    "Four Horsemen": {
+      "label": "Four Horsemen",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "c65a1044-4033-5737-8b59-80d5bbdff9ce",
+          "_name": "War"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "471de767-46ba-5c3b-baaa-101b13022be1",
+          "_name": "Famine"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "81e18441-008e-5f51-90b8-b0f768ced6b3",
+          "_name": "Pestilence"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "6940d2fd-b398-5989-8d91-39c0ed0a46ce",
+          "_name": "Death"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "33293290-b1dd-5c5a-8d59-2982ca6c8d68",
+          "_name": "The Horsemen of Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f7d9a78a-ea14-5ada-aa03-ff7523e14c45",
+          "_name": "The Ravages of War"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "60be15fc-ce8d-5520-900c-f79840b3115d",
+          "_name": "A Time of Famine"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fa4bd329-4b55-5fd7-aec3-2e01da917c3d",
+          "_name": "Plague and Pestilence"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "57da8118-0776-5abf-ba2e-d81ada662032",
+          "_name": "The Specter of Death"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "c0c8b6be-35cf-5bba-bd68-56d8c4fafd94",
+          "_name": "Golden Horse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "378a0808-ae3b-5634-97e0-98f2406300d6",
+          "_name": "Metal Wings"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b673cd17-95a3-5daf-9ac1-00f32567e9e4",
+          "_name": "Horseman of War"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ecbed649-2258-5fc3-9156-d00f57c6d142",
+          "_name": "Horseman of Famine"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9898c0f6-072e-5cc7-83fb-809412d1e9e0",
+          "_name": "Horseman of Pestilence"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "86ed0536-2162-53ac-9f45-8482b6190343",
+          "_name": "Horseman of Death"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "33e5be1c-902d-596c-8139-69f71da6dae3",
+          "_name": "Rough Riders"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Four Horsemen"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Hounds": {
+      "label": "Hounds",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ecbcdcbb-1e7b-50b4-b920-5dc4f2ce0987",
+          "_name": "Release the Hounds"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "63a7cd11-9812-556c-8fe8-5f947778b5e1",
+          "_name": "Ahab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "991e9a14-f053-56cf-9c24-ca3d56234c1b",
+          "_name": "Hound"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7d6e9839-39d1-5439-9316-4647b4129589",
+          "_name": "Ahab's Energy Spear"
+        }
+      ]
+    },
+    "Apocalypse": {
+      "label": "Apocalypse",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d0ae4f92-0b89-5e90-9b66-eecf6c0bb57a",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "7780b3c7-33c2-5e98-bfd7-6f4660737745",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "8d278955-1cb2-59a4-8cc5-e8dc1a7865a6",
+          "_name": "The Age of Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bf27cf14-f676-5e98-a3df-f323aaa8730c",
+          "_name": "Heart of the Empire"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f324259-e9ea-5178-909c-b00283c85982",
+          "_name": "The Tyrant's Throne"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "38b51411-200e-503a-a840-7f22cd9e2b23",
+          "_name": "Cyberpathy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f5a35958-e0f8-5880-b83b-3bfc13595944",
+          "_name": "Biomorphing"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "568818c1-e1e6-5e2a-8d32-a54c6bab0a35",
+          "_name": "Molecular Control"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f5b33980-7fde-5079-8f24-79cf78b9fb03",
+          "_name": "The Fittest"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e5ed7a11-b247-5db3-b133-9e3ccdc7f59f",
+          "_name": "Wolf Among Sheep"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7a1283ce-7853-581b-96d0-c2933dbca855",
+          "_name": "The Apocalypse Solution"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Apocalypse"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Apocalypse"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Dark Riders": {
+      "label": "Dark Riders",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "286fcb20-2528-5209-bd27-0dfe93abd15b",
+          "_name": "Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "da4f8059-132b-575e-b1b4-59216802e473",
+          "_name": "Barrage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8043247c-7755-5ade-b814-0bdfad5bd1ad",
+          "_name": "Hard-Drive"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4a70b9f2-23d9-56bd-be3a-0f5f7f503470",
+          "_name": "Tusk"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "716167f8-e46d-55cb-ad8b-df4c6685fbe3",
+          "_name": "Psynapse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1e0dbecf-e054-5643-9485-05c53933b2e4",
+          "_name": "The Dark Riders"
+        }
+      ]
+    },
+    "Dark Beast": {
+      "label": "Dark Beast",
+      "cards": [
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "9b47f411-6b41-5376-817a-485897c89c58",
+          "_name": "Dark Beast"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "ad41ac90-940f-5708-8782-696ab86f66cb",
+          "_name": "Dark Beast"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "405f1242-aad7-58b3-a005-10ed54470fa2",
+          "_name": "Dark Beast"
+        },
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "55eedbff-7b14-50eb-be07-a023cc76af8e",
+          "_name": "Dark Beast's Bogus Journey"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a677d598-f0bd-520f-ad05-1fe68a6040d0",
+          "_name": "High-Tech Goggles"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "352346cc-30d1-532c-884e-08f24ed60368",
+          "_name": "Genetic Enhancement"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2fd2dcd1-6c6d-5ea1-89c1-8e86fe9b87c6",
+          "_name": "Cruel Experiment"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f141d01-78ac-5104-a0ce-8e4051ea2d27",
+          "_name": "Evil Genius"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6997ebf9-6691-53dd-a19f-1a5525eb3f17",
+          "_name": "Time-Travel Shenanigans"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_REQUIRED",
+          "Dark Beast"
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "Dark Beast"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Savage Land": {
+      "label": "Savage Land",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9dfdf35b-c735-52a8-9bff-05936309971f",
+          "_name": "The Savage Land"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d693e960-5875-50dd-bb56-374d4e8af056",
+          "_name": "Pterosaur"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "740c7051-e3db-5248-9029-e30d38b26848",
+          "_name": "Velociraptor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7ee3c21d-43fa-58bf-8b0f-d66791e2abc6",
+          "_name": "Giant Ape"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "255e8a08-e685-5b9d-a9c4-31f414dbd9fd",
+          "_name": "Land Out of Time"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "37af4445-20d9-55b6-aeb3-1d745ec02444",
+          "_name": "Village Under Attack"
+        }
+      ]
+    },
+    "Genosha": {
+      "label": "Genosha",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4d094b29-1c48-5105-82e8-b4fa686697b6",
+          "_name": "Genosha"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3a9a1960-cc05-573c-a950-92c8b3b88fee",
+          "_name": "Magistrate"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "63228314-5eec-53e5-b84a-1ff72ff5f41e",
+          "_name": "Armored Unibike"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f27d17b9-d59f-5e76-b793-25fba5b6723f",
+          "_name": "Genoshan Mech"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12a4f828-e7ba-5788-8671-c39bc4f6ecd5",
+          "_name": "Escaped Mutant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "461356ca-97b6-51d4-9a2a-9daa4f43175c",
+          "_name": "Police State"
+        }
+      ]
+    },
+    "Blue Moon": {
+      "label": "Blue Moon",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d1449f8e-0be3-5697-a7a5-2a10f8309f19",
+          "_name": "Blue Area of the Moon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dad256a8-6860-5664-a7bc-92e5dbdedead",
+          "_name": "Gladiator"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "15d72771-f7e1-5cbf-aa1a-b731935ff6a9",
+          "_name": "Oracle"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0d404b9a-f094-5ad6-9778-b58c7945b7d6",
+          "_name": "Manta"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c9064553-11dd-5a40-b619-c8a5d833d3c3",
+          "_name": "Earthquake"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d336f129-7ab0-56a1-857d-df531ac6cb44",
+          "_name": "Warstar"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0c30d078-b10e-5e62-b3ec-e16e1593fa7f",
+          "_name": "Imperial Guardsman"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e917680e-c3a8-5c8b-b5db-b58f463080c6",
+          "_name": "Trial by Combat"
+        }
+      ]
+    },
+    "En Sabah Nur": {
+      "label": "En Sabah Nur",
+      "cards": [
+        {
+          "loadGroupId": "sharedMainScheme",
+          "quantity": 1,
+          "databaseId": "32486e5b-b653-59ad-b5bc-200446cadcf4",
+          "_name": "En Sabah Nur's Pyramid"
+        },
+        {
+          "loadGroupId": "sharedMainSchemeDeck",
+          "quantity": 1,
+          "databaseId": "a2667725-acc3-5cb4-aaa8-080e8b1e9660",
+          "_name": "The Rise of Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c8de4118-f2c5-519f-ada8-82f417dac23b",
+          "_name": "Staggering Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bdf0361d-bced-5fb2-a6b3-2e0d37ab0f82",
+          "_name": "Biomorphic Blast"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "09e4cb77-150f-54e8-800e-f69fbd1d6bdb",
+          "_name": "Technological Interface"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f53459f-aa48-5b2b-8238-7ce63e95752c",
+          "_name": "Giant-Sized Despot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f756642-393b-5dea-9ac5-7e77e35988d6",
+          "_name": "Source of Power"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "889302d7-b845-5a02-a0c8-4e58994aedee",
+          "_name": "Plugged In"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "69f4870b-18c9-5529-a436-02e19de7600a",
+          "_name": "Giant Growth"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d61f4f92-c4a8-5ba8-ba03-5977608c32cd",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "d61f4f92-c4a8-5ba8-ba03-5977608c32cd",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "fd8021b1-b523-557b-8edf-956bca274dd5",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "fd8021b1-b523-557b-8edf-956bca274dd5",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3f697d66-bbd7-5343-b6fb-6cb740463ab1",
+          "_name": "Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedVillainDeck",
+          "quantity": 1,
+          "databaseId": "3f697d66-bbd7-5343-b6fb-6cb740463ab1",
+          "_name": "Apocalypse"
+        }
+      ],
+      "postLoadActionList": [
+        [
+          "SET",
+          "/layoutVariants/largeMainScheme",
+          false
+        ],
+        [
+          "LOAD_RECOMMENDS",
+          "En Sabah Nur"
+        ],
+        [
+          "ACTION_LIST",
+          "loadMode"
+        ]
+      ]
+    },
+    "Celestial Tech": {
+      "label": "Celestial Tech",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "37f6936b-d671-54d3-82fe-49b828f96ee3",
+          "_name": "Celestial Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bc8191ba-94e8-596c-b797-4065b2edd63f",
+          "_name": "Celestial Weapon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c297ff6f-44f3-5393-a54e-b8050aa217b9",
+          "_name": "Celestial Tech"
+        }
+      ]
+    },
+    "Clan Akkaba": {
+      "label": "Clan Akkaba",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3b524d41-26c0-535e-8a79-539d358a3480",
+          "_name": "Ozymandias"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8dc3e2e6-2392-5eb3-ab20-f24cba97a582",
+          "_name": "Scarab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "eedcbd12-1b47-5352-9d64-f05031b4a64a",
+          "_name": "Clan Akkaba Zealot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9a6f845b-f075-535c-bf6e-c849b43500ad",
+          "_name": "Tyrant Worship"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ed8ba784-fccd-5b70-af65-3ec58f13ebd9",
+          "_name": "Ancient Ritual"
+        }
+      ]
+    },
+    "Age of Apocalypse": {
+      "label": "Age of Apocalypse",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 2,
+          "databaseId": "6e104fd5-5415-50af-bb28-b7e2dcc2bf44",
+          "_name": "Agent of Apocalypse"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 2,
+          "databaseId": "b1c2f0df-07d9-54bb-b57d-92793ed712e0",
+          "_name": "Worldwide Crisis"
+        }
+      ]
+    },
+    "Mission": {
+      "label": "Mission",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "70f02a4f-87fa-5718-a450-7a0a63eaa274",
+          "_name": "Liberate the Seattle Core"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "264b0fdd-5dbf-57b7-9e7c-972b2bf0f3d8",
+          "_name": "Evacuate Survivors"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "2a894e58-82b9-5c7f-9e1f-2d9cc109168c",
+          "_name": "Sabotage the Sea Wall"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "0be33344-8bc3-58ca-ba9e-cb7bfda55d96",
+          "_name": "Find Lost Mutants"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "a5c6fbb8-a798-5324-beb9-14587c9ff0b3",
+          "_name": "Protect the Professor"
+        }
+      ]
+    },
+    "Campaign (Age of Apocalypse)": {
+      "label": "Campaign (Age of Apocalypse)",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "be736549-a987-5a9a-8cd5-bb2f4690c79a",
+          "_name": "Mission Team"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "2d2d2e42-6400-58d5-bb76-c745a366d7b6",
+          "_name": "Destiny"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "1c395bd3-ad2f-5000-b9ca-dceb596f56e0",
+          "_name": "Blink"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "213099b6-1096-53e8-9079-661c18b7ba46",
+          "_name": "Morph"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "e0d57a70-731e-52d5-8344-062fbe7cb372",
+          "_name": "X-Man"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "c60d565e-0b09-5274-b1ae-5f8f0824b364",
+          "_name": "Desperate Measures"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "0cd33f61-0f1f-53e4-8b8e-f2c82920d370",
+          "_name": "North American Sea Wall"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 4,
+          "databaseId": "2d5fac31-dad6-5269-adc9-4fc6efa40591",
+          "_name": "Panicked Refugees"
+        }
+      ]
+    },
+    "Overseer": {
+      "label": "Overseer",
+      "cards": [
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "f70e9fa5-5f2a-5b85-8e59-21c5e3123bf9",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "31e8f2a1-1bd3-5ecd-a701-68ea671c3a99",
+          "_name": "The Shadow King"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "2eefb239-9068-501e-98a6-e933a560a260",
+          "_name": "Abyss"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "2cf2e0ea-2ce5-56c3-af6a-8eda8204cdab",
+          "_name": "Sugar Man"
+        },
+        {
+          "loadGroupId": "sharedCampaignDeck",
+          "quantity": 1,
+          "databaseId": "f0c9b0b6-8c76-5037-b09a-b79e781801ee",
+          "_name": "Mikhail Rasputin"
+        }
+      ]
+    },
+    "The Sinister Six (required)": {
+      "label": "The Sinister Six (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "86cb308f-f8a2-59d8-8ccd-45a8f1c7e1c6",
+          "_name": "Life-Size Decoy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a10be59f-70aa-551e-88a6-964f4d9fbb8a",
+          "_name": "Coordinated Effort"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0850115d-10ae-5a2d-a6e5-411457676b9d",
+          "_name": "Hidden in Shadow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "757e5fce-9acc-5a92-8e98-b0d0b88ecc4b",
+          "_name": "Teamwork Makes the Dream Work"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "94db4813-0d4e-54e4-b8da-7af62c76d08a",
+          "_name": "From Every Direction"
+        }
+      ]
+    },
+    "Stryfe (required)": {
+      "label": "Stryfe (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e9d08f29-af52-590d-bc2c-37498c3fc919",
+          "_name": "Hope Summers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4d43d2da-ad2e-5377-b374-504644255c0a",
+          "_name": "Captive Hope"
+        }
+      ]
+    },
+    "Infiltrate the Museum (required)": {
+      "label": "Infiltrate the Museum (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e2781ad-cb6c-546c-8790-d31fdab51cd9",
+          "_name": "Cloak of Hercules"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "25771d4b-4583-59cb-883e-d66b495ebf27",
+          "_name": "Obedience Potion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f98ea4b-e39e-5b9e-89d2-f22d4478c161",
+          "_name": "The Beyonder's Blazer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "30139e24-5eb9-5c7b-a931-c32990848aa7",
+          "_name": "The Poison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "81c9beda-77ae-5580-8f7c-eb542adfefbd",
+          "_name": "Vandarian Power Wand"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a313f69a-3e25-5040-907c-399e26716a79",
+          "_name": "Hujahdarian Monarch Egg"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0f75a3ea-da2a-5f33-97f3-e1bb05971a83",
+          "_name": "Magical Teapot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3c23b60f-cb20-55a2-be54-466530103845",
+          "_name": "Philosopher's Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3bb60999-05dd-5260-b52e-2830b8a0ca20",
+          "_name": "Crystal Ball"
+        }
+      ]
+    },
+    "Escape the Museum (required)": {
+      "label": "Escape the Museum (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e2781ad-cb6c-546c-8790-d31fdab51cd9",
+          "_name": "Cloak of Hercules"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "25771d4b-4583-59cb-883e-d66b495ebf27",
+          "_name": "Obedience Potion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f98ea4b-e39e-5b9e-89d2-f22d4478c161",
+          "_name": "The Beyonder's Blazer"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "30139e24-5eb9-5c7b-a931-c32990848aa7",
+          "_name": "The Poison"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "81c9beda-77ae-5580-8f7c-eb542adfefbd",
+          "_name": "Vandarian Power Wand"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a313f69a-3e25-5040-907c-399e26716a79",
+          "_name": "Hujahdarian Monarch Egg"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0f75a3ea-da2a-5f33-97f3-e1bb05971a83",
+          "_name": "Magical Teapot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3c23b60f-cb20-55a2-be54-466530103845",
+          "_name": "Philosopher's Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3bb60999-05dd-5260-b52e-2830b8a0ca20",
+          "_name": "Crystal Ball"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "ad8439f9-b46e-5aa6-9f79-4184c8c033f3",
+          "_name": "Milano"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "a7c220fb-0135-51fa-91da-df3a5ef922bc",
+          "_name": "Rogue Vessel"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "db42a59c-452b-5001-a030-4477ff5a371f",
+          "_name": "Cannonade"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "3f1f6c1c-dac1-5ba8-8270-74b81e5e4d23",
+          "_name": "Blind Side"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "89c215e7-3f21-5edc-8ab0-c7d2af5548aa",
+          "_name": "Hull Breach"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "2afe6621-12bc-5f71-bc72-b0859ddae29d",
+          "_name": "Power Siphon"
+        },
+        {
+          "loadGroupId": "sharedOutOfPlay",
+          "quantity": 1,
+          "databaseId": "538950af-1642-54fa-ba20-befffb3e327e",
+          "_name": "Special Delivery"
+        }
+      ]
+    },
+    "Crossbones (required)": {
+      "label": "Crossbones (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounter3Deck",
+          "quantity": 1,
+          "databaseId": "318c8d5f-7577-55a8-98ba-e31f9069c9f5",
+          "_name": "Laser Rifle"
+        },
+        {
+          "loadGroupId": "sharedEncounter3Deck",
+          "quantity": 1,
+          "databaseId": "54e8f1a4-f4ff-5694-9304-15ad7cbe30be",
+          "_name": "Energy Shield"
+        },
+        {
+          "loadGroupId": "sharedEncounter3Deck",
+          "quantity": 1,
+          "databaseId": "095c40d0-c564-5174-9faf-9e07b6f20e93",
+          "_name": "Power Gauntlets"
+        },
+        {
+          "loadGroupId": "sharedEncounter3Deck",
+          "quantity": 1,
+          "databaseId": "9554f736-800f-5146-a128-ae3e4f9b1864",
+          "_name": "Exo-Suit"
+        }
+      ]
+    },
+    "Loki (required)": {
+      "label": "Loki (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "588ac077-fcb5-5bc1-bfa0-03b43756fa0e",
+          "_name": "Infinity Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "3277a37a-ede4-5100-9ed9-7ca638cf1d20",
+          "_name": "Mind Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "5c64001d-a0f9-536c-a8e7-65f5cb055f3c",
+          "_name": "Power Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "05c46b1b-6c55-50a9-90a7-1f251654393f",
+          "_name": "Reality Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "85d41b03-1e25-57f2-b6e7-e02047b60a64",
+          "_name": "Soul Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "ff79201c-d6d2-5e54-8e23-c90f6c623234",
+          "_name": "Space Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "83878bd5-4a4b-5b15-a58c-be916684852b",
+          "_name": "Time Stone"
+        }
+      ]
+    },
+    "Nebula (required)": {
+      "label": "Nebula (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "77738a60-281e-5bf9-bc1a-456d2dd4cb69",
+          "_name": "Power Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ad8439f9-b46e-5aa6-9f79-4184c8c033f3",
+          "_name": "Milano"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a7c220fb-0135-51fa-91da-df3a5ef922bc",
+          "_name": "Rogue Vessel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db42a59c-452b-5001-a030-4477ff5a371f",
+          "_name": "Cannonade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f1f6c1c-dac1-5ba8-8270-74b81e5e4d23",
+          "_name": "Blind Side"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c215e7-3f21-5edc-8ab0-c7d2af5548aa",
+          "_name": "Hull Breach"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2afe6621-12bc-5f71-bc72-b0859ddae29d",
+          "_name": "Power Siphon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "538950af-1642-54fa-ba20-befffb3e327e",
+          "_name": "Special Delivery"
+        }
+      ]
+    },
+    "Ronan the Accuser (required)": {
+      "label": "Ronan the Accuser (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "77738a60-281e-5bf9-bc1a-456d2dd4cb69",
+          "_name": "Power Stone"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ad8439f9-b46e-5aa6-9f79-4184c8c033f3",
+          "_name": "Milano"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a7c220fb-0135-51fa-91da-df3a5ef922bc",
+          "_name": "Rogue Vessel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db42a59c-452b-5001-a030-4477ff5a371f",
+          "_name": "Cannonade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f1f6c1c-dac1-5ba8-8270-74b81e5e4d23",
+          "_name": "Blind Side"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c215e7-3f21-5edc-8ab0-c7d2af5548aa",
+          "_name": "Hull Breach"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2afe6621-12bc-5f71-bc72-b0859ddae29d",
+          "_name": "Power Siphon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "538950af-1642-54fa-ba20-befffb3e327e",
+          "_name": "Special Delivery"
+        }
+      ]
+    },
+    "Taskmaster (required)": {
+      "label": "Taskmaster (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8b80afb9-e793-5d19-9d96-4a181c220723",
+          "_name": "Hydra Patrol"
+        }
+      ]
+    },
+    "Thanos (required)": {
+      "label": "Thanos (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "588ac077-fcb5-5bc1-bfa0-03b43756fa0e",
+          "_name": "Infinity Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "3277a37a-ede4-5100-9ed9-7ca638cf1d20",
+          "_name": "Mind Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "5c64001d-a0f9-536c-a8e7-65f5cb055f3c",
+          "_name": "Power Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "05c46b1b-6c55-50a9-90a7-1f251654393f",
+          "_name": "Reality Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "85d41b03-1e25-57f2-b6e7-e02047b60a64",
+          "_name": "Soul Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "ff79201c-d6d2-5e54-8e23-c90f6c623234",
+          "_name": "Space Stone"
+        },
+        {
+          "loadGroupId": "sharedInfinityGauntletDeck",
+          "quantity": 1,
+          "databaseId": "83878bd5-4a4b-5b15-a58c-be916684852b",
+          "_name": "Time Stone"
+        }
+      ]
+    },
+    "Brotherhood of Badoon (required)": {
+      "label": "Brotherhood of Badoon (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ad8439f9-b46e-5aa6-9f79-4184c8c033f3",
+          "_name": "Milano"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a7c220fb-0135-51fa-91da-df3a5ef922bc",
+          "_name": "Rogue Vessel"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db42a59c-452b-5001-a030-4477ff5a371f",
+          "_name": "Cannonade"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3f1f6c1c-dac1-5ba8-8270-74b81e5e4d23",
+          "_name": "Blind Side"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c215e7-3f21-5edc-8ab0-c7d2af5548aa",
+          "_name": "Hull Breach"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2afe6621-12bc-5f71-bc72-b0859ddae29d",
+          "_name": "Power Siphon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "538950af-1642-54fa-ba20-befffb3e327e",
+          "_name": "Special Delivery"
+        }
+      ]
+    },
+    "Project Wideawake (required)": {
+      "label": "Project Wideawake (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "76a17f90-2129-5d2f-a92a-3b93fdc78bf9",
+          "_name": "Sentinel Mark II"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "39d48355-58a9-55cc-88f8-d2d9e8776a09",
+          "_name": "Sentinel Mark III"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "668e0cb6-0315-5e2a-85ab-a22f79e6e22e",
+          "_name": "Energy Barrier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c65aa8ac-ee8b-527c-8d66-ae62e5a9f77f",
+          "_name": "Operation Zero Tolerance"
+        }
+      ]
+    },
+    "Master Mold (required)": {
+      "label": "Master Mold (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6bff7ff9-7812-5307-a87c-fd87fe934051",
+          "_name": "Sentinel Mark V"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ac2da7ef-a326-5519-96d4-b60bf66aa7bf",
+          "_name": "Sentinel Mark VI"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5b8721de-ccf1-58e3-a659-da10eb85a9da",
+          "_name": "Targeted for Elimination"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dee7b19d-f15a-57f3-aadb-c1e7b7788cbc",
+          "_name": "Relentless Robots"
+        }
+      ]
+    },
+    "Mansion Attack (required)": {
+      "label": "Mansion Attack (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e4d371f-121a-5026-a95f-d1cf018c9935",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "249f2dba-16bd-5926-b90d-713184a7231d",
+          "_name": "Blob"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "829f832a-4c4d-5ebe-8fd5-e733a7ee4cf8",
+          "_name": "Pyro"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adb49983-fa24-5a6f-b0e1-3c927a0a7f78",
+          "_name": "Toad"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c46d681c-43fa-58ed-88b9-d842c269dda7",
+          "_name": "Homo Superior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c09d7f-e00d-5c5e-8572-2815c7a1d5db",
+          "_name": "Mutant Terrorists"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12741201-1920-59b0-b7a7-828565eee855",
+          "_name": "The Brotherhood"
+        }
+      ]
+    },
+    "Sandman (required)": {
+      "label": "Sandman (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b80e3792-2ef8-58a6-80a1-0f0d61f8c46b",
+          "_name": "Panic in the Streets"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ca41bcf8-6591-5c4f-bfe2-b83c42a8ce67",
+          "_name": "Rhino"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c64835f1-90d4-5778-966e-ca13d4e34f0a",
+          "_name": "Calling in Favors"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "321d6d55-64e6-525b-8c6c-bbd412289141",
+          "_name": "Now or Never"
+        }
+      ]
+    },
+    "Mysterio (required)": {
+      "label": "Mysterio (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ecfdffcd-0ebd-57ba-a673-46d03cf005e6",
+          "_name": "Induced Panic"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "008b3a59-fd80-5861-b52b-225ecff1746b",
+          "_name": "Evil Doppelgänger"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3cea8feb-c28e-5f69-9cbb-318e494b4493",
+          "_name": "Fool's Paradise"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7a7d346f-420c-59a9-892a-8edc48d6ee60",
+          "_name": "Weakness from Within"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "cdd99c14-e7d2-5ebb-a2de-bf150443ec76",
+          "_name": "Deepest Fears"
+        }
+      ]
+    },
+    "Venom (required)": {
+      "label": "Venom (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c78c238e-360b-5824-bc52-21b8dd732224",
+          "_name": "Improvised Weapons"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0577f48c-1344-5eaa-b0cb-df91750f37c1",
+          "_name": "Violent Tendencies"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b7e0cf48-cf86-5487-93e1-dd08e86b5933",
+          "_name": "Webbed Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "7f2c2deb-dbac-595f-baff-5974ec577055",
+          "_name": "Enraged Symbiote"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1bd73c69-8057-5675-b12a-78c2babac149",
+          "_name": "Swinging Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41f2143b-6d8d-53a0-84dd-9251e52f6114",
+          "_name": "Unstable Sentience"
+        }
+      ]
+    },
+    "Venom Goblin (required)": {
+      "label": "Venom Goblin (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c78c238e-360b-5824-bc52-21b8dd732224",
+          "_name": "Improvised Weapons"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0577f48c-1344-5eaa-b0cb-df91750f37c1",
+          "_name": "Violent Tendencies"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b7e0cf48-cf86-5487-93e1-dd08e86b5933",
+          "_name": "Webbed Up"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "7f2c2deb-dbac-595f-baff-5974ec577055",
+          "_name": "Enraged Symbiote"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1bd73c69-8057-5675-b12a-78c2babac149",
+          "_name": "Swinging Assault"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "41f2143b-6d8d-53a0-84dd-9251e52f6114",
+          "_name": "Unstable Sentience"
+        }
+      ]
+    },
+    "On the Run (required)": {
+      "label": "On the Run (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2b5020bb-12ab-5428-bd78-1c609378e8ea",
+          "_name": "Vertigo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adc7631f-1955-51d7-bc87-85b811f97fe1",
+          "_name": "Mutant Slayers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "48e4b9cb-c160-5fd6-925e-0b43ef5ae6b7",
+          "_name": "Bound by Business"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0b5ee34-867f-53fd-8905-5d00b6c331e7",
+          "_name": "Arclight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "998f2ab6-0aca-5519-9fb6-5b0cc9427e4d",
+          "_name": "Blockbuster"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bde99f9e-1c71-5a7e-99ca-dbbfaa306063",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2a5b5c36-f6fd-5d06-9513-6e7fee1a3f89",
+          "_name": "Greycrow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5a0b2bf6-c83f-5d84-93a8-63157e7c9940",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "84f643ee-8378-53b5-9307-adcc0477510d",
+          "_name": "Riptide"
+        }
+      ]
+    },
+    "Juggernaut (required)": {
+      "label": "Juggernaut (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e9d08f29-af52-590d-bc2c-37498c3fc919",
+          "_name": "Hope Summers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4d43d2da-ad2e-5377-b374-504644255c0a",
+          "_name": "Captive Hope"
+        }
+      ]
+    },
+    "Mister Sinister (required)": {
+      "label": "Mister Sinister (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4e336ee6-33cb-571f-9e5d-3087dc93a971",
+          "_name": "Flight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6699829e-96d8-5cce-bc1e-ca3b1b0febdf",
+          "_name": "Aerial Bombardment"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7f5174ac-7ac5-57cd-89f0-15bbf1932dd1",
+          "_name": "Out of Reach"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "764273b6-b004-557f-85fc-26799f54697b",
+          "_name": "High Ground"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a3f46fd8-5e1e-5009-b180-9156bf2b98c6",
+          "_name": "Super Strength"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "84b1591a-0388-5bd1-b590-177d0c9a2bee",
+          "_name": "Impervious"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6cb93cb7-f0ec-58aa-9bfb-17f68be67feb",
+          "_name": "Thrown Oject"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b0f9f2a3-6842-5a33-a0ae-fa042e0e4445",
+          "_name": "\"I'll Take That\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9579ef5b-1a1d-5e8e-b868-fc3fc704423b",
+          "_name": "Telepathy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5812391b-2f8a-5258-a267-dc897bce1f87",
+          "_name": "Manufactured Drama"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c849cfc8-256c-5818-8210-1d13f298da1a",
+          "_name": "Sowing Discord"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "74f84e31-9d5b-5767-9ca3-a69a14a319eb",
+          "_name": "One Step Ahead"
+        }
+      ]
+    },
+    "Unus (required)": {
+      "label": "Unus (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9db49225-3bad-50dd-a8bc-ba23873a1b63",
+          "_name": "Infinite Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "aaf106a6-8751-55f0-916c-1ace93a1bb6c",
+          "_name": "Culling the Weak"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "01c842cb-66a5-55d0-bf3c-c0d7908fda97",
+          "_name": "Gene Pool"
+        }
+      ]
+    },
+    "Dark Beast (required)": {
+      "label": "Dark Beast (required)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d1449f8e-0be3-5697-a7a5-2a10f8309f19",
+          "_name": "Blue Area of the Moon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dad256a8-6860-5664-a7bc-92e5dbdedead",
+          "_name": "Gladiator"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "15d72771-f7e1-5cbf-aa1a-b731935ff6a9",
+          "_name": "Oracle"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0d404b9a-f094-5ad6-9778-b58c7945b7d6",
+          "_name": "Manta"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c9064553-11dd-5a40-b619-c8a5d833d3c3",
+          "_name": "Earthquake"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d336f129-7ab0-56a1-857d-df531ac6cb44",
+          "_name": "Warstar"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0c30d078-b10e-5e62-b3ec-e16e1593fa7f",
+          "_name": "Imperial Guardsman"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e917680e-c3a8-5c8b-b5db-b58f463080c6",
+          "_name": "Trial by Combat"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4d094b29-1c48-5105-82e8-b4fa686697b6",
+          "_name": "Genosha"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3a9a1960-cc05-573c-a950-92c8b3b88fee",
+          "_name": "Magistrate"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "63228314-5eec-53e5-b84a-1ff72ff5f41e",
+          "_name": "Armored Unibike"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f27d17b9-d59f-5e76-b793-25fba5b6723f",
+          "_name": "Genoshan Mech"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12a4f828-e7ba-5788-8671-c39bc4f6ecd5",
+          "_name": "Escaped Mutant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "461356ca-97b6-51d4-9a2a-9daa4f43175c",
+          "_name": "Police State"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9dfdf35b-c735-52a8-9bff-05936309971f",
+          "_name": "The Savage Land"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d693e960-5875-50dd-bb56-374d4e8af056",
+          "_name": "Pterosaur"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "740c7051-e3db-5248-9029-e30d38b26848",
+          "_name": "Velociraptor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "7ee3c21d-43fa-58bf-8b0f-d66791e2abc6",
+          "_name": "Giant Ape"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "255e8a08-e685-5b9d-a9c4-31f414dbd9fd",
+          "_name": "Land Out of Time"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "37af4445-20d9-55b6-aeb3-1d745ec02444",
+          "_name": "Village Under Attack"
+        }
+      ]
+    },
+    "Apocalypse (required)": {
+      "label": "Apocalypse (required)",
+      "cards": []
+    },
+    "Stryfe (recommends)": {
+      "label": "Stryfe (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fa1f359e-95b8-576d-9a46-7bbeeac489b5",
+          "_name": "Strobe"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "75d695cd-cb18-580d-a3fe-96cb63cd2e99",
+          "_name": "Tempo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3eb0a9a5-ab1f-51a7-891f-a8c9bced3ae6",
+          "_name": "Thumbelina"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "969c0d52-72ab-5610-b582-70e5eb0d3418",
+          "_name": "Wildside"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43278d54-1d0a-55fb-b927-8881da20df9b",
+          "_name": "Extreme Measures"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "029572a6-3e52-5d9e-ab46-69326854cb83",
+          "_name": "Dragoness"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bb730ae3-a59c-5eb5-bd9d-d35eb33e5379",
+          "_name": "Forearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adc3c28b-e016-54cb-a55e-4986d9bf9028",
+          "_name": "Reaper"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9236c1ad-5aca-5dd8-91d8-7061097abb64",
+          "_name": "Samurai"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7aebe1c1-c9b3-55fc-ab1a-a712e72e3b04",
+          "_name": "Mutant Insurrection"
+        }
+      ]
+    },
+    "Rhino (recommends)": {
+      "label": "Rhino (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7d08b829-a72c-5475-a4c7-b5c383b65494",
+          "_name": "Bomb Scare"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b50d78d6-b5a2-5d5c-bfe8-514808c3a29e",
+          "_name": "Hydra Bomber"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "461a921e-f4f4-5ce1-a1fe-6a6d8454c4e7",
+          "_name": "Explosion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9f448db8-d667-5e7a-a612-4321c446a0f7",
+          "_name": "False Alarm"
+        }
+      ]
+    },
+    "Klaw (recommends)": {
+      "label": "Klaw (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e9f795f0-4d7f-5ff9-8faa-3edd58c1a131",
+          "_name": "The Masters of Evil"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a99cb606-466e-5768-a121-994535002b90",
+          "_name": "Radioactive Man"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "233eb938-6120-5193-8cba-68adff018df7",
+          "_name": "Whirlwind"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e7f59f60-0f6f-5f1c-88fb-8cd543673073",
+          "_name": "Tiger Shark"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eb0962c4-fcad-5b8e-8b2e-28c8fe552827",
+          "_name": "Melter"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9f9a9ee2-aa22-5583-b87b-5d5e88e5cce2",
+          "_name": "Masters of Mayhem"
+        }
+      ]
+    },
+    "Red Skull (recommends)": {
+      "label": "Red Skull (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "a0b55d92-d818-5e48-ac2d-9fc58b02f79d",
+          "_name": "Hydra Flame-Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2dd3a5a7-3549-546e-b09d-1f596c93e10e",
+          "_name": "Hydra Jet-Trooper"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8b80afb9-e793-5d19-9d96-4a181c220723",
+          "_name": "Hydra Patrol"
+        }
+      ]
+    },
+    "Ultron (recommends)": {
+      "label": "Ultron (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "53e4fdb4-6888-5351-b297-498285d36c3f",
+          "_name": "Under Attack"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af2a0ce9-dc62-5e85-b02d-88eea7412c6e",
+          "_name": "Vibranium Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b6048f64-f3a1-5635-8c75-72fe67e4d6a7",
+          "_name": "Concussion Blasters"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "29661103-0fbc-55ba-929e-292d4a695e05",
+          "_name": "Concussive Blast"
+        }
+      ]
+    },
+    "Kang (recommends)": {
+      "label": "Kang (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "0b7bee4f-0c4f-50d8-8838-568a4fe0bdc0",
+          "_name": "Ancient Warrior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "34db0149-ba73-537a-9bb7-5a5f8ceef134",
+          "_name": "Chitauri Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "59681b29-3907-55fd-ac24-360bd3813b26",
+          "_name": "Tyrannosaurus Rex"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "544834e6-6db3-5745-884d-e7067195f789",
+          "_name": "Time Portal"
+        }
+      ]
+    },
+    "Absorbing Man (recommends)": {
+      "label": "Absorbing Man (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8b80afb9-e793-5d19-9d96-4a181c220723",
+          "_name": "Hydra Patrol"
+        }
+      ]
+    },
+    "Infiltrate the Museum (recommends)": {
+      "label": "Infiltrate the Museum (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "55bc4a36-12d8-57d8-97a4-d58d62003018",
+          "_name": "Psionic Ghost"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "6a27c000-a39f-5836-8db7-986b8f30830b",
+          "_name": "Servant Bot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3b6aa2e3-8dca-58fe-b19f-e088edce121a",
+          "_name": "Starshark"
+        }
+      ]
+    },
+    "Escape the Museum (recommends)": {
+      "label": "Escape the Museum (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "55bc4a36-12d8-57d8-97a4-d58d62003018",
+          "_name": "Psionic Ghost"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "6a27c000-a39f-5836-8db7-986b8f30830b",
+          "_name": "Servant Bot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3b6aa2e3-8dca-58fe-b19f-e088edce121a",
+          "_name": "Starshark"
+        }
+      ]
+    },
+    "Crossbones (recommends)": {
+      "label": "Crossbones (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "a0b55d92-d818-5e48-ac2d-9fc58b02f79d",
+          "_name": "Hydra Flame-Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2dd3a5a7-3549-546e-b09d-1f596c93e10e",
+          "_name": "Hydra Jet-Trooper"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4355ac3d-c683-56b2-9072-63efc2185fd5",
+          "_name": "Legions of Hydra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ece93ded-b490-5d34-b9e8-47049e032935",
+          "_name": "Madame Hydra"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fecf8e5e-b9bf-571a-807d-5b02f7eca9cb",
+          "_name": "Combat Knife"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7c9e0604-3ca2-51cc-aa95-50cb84e90797",
+          "_name": "Hydra Sidearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d94f00fc-03d9-536f-a2cf-c2e925b01228",
+          "_name": "Weapon Master"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "78391cb4-22b0-5c80-a7cc-6c135c2ba917",
+          "_name": "Concussion Grenade"
+        }
+      ]
+    },
+    "Ebony Maw (recommends)": {
+      "label": "Ebony Maw (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a4dfc65c-0604-5033-9630-64d0d051f5f2",
+          "_name": "Black Order Infantry"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "def0b699-9b56-55f6-8943-b4800037b0ea",
+          "_name": "Outrider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f359f1ed-bbed-5ae4-845d-2074d5b86fe3",
+          "_name": "Landing Craft"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43fdc637-c3e3-59e9-a3c9-2569d79cfd73",
+          "_name": "Black Dwarf"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af63dfc3-2186-5422-bb33-c5bd4dea6715",
+          "_name": "Supergiant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "51e0cc3b-0983-5f49-955e-4a8cb28d8c68",
+          "_name": "The Black Order"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a0d2ac73-d416-55a6-b952-0c359714389b",
+          "_name": "Blood to Spare"
+        }
+      ]
+    },
+    "Hela (recommends)": {
+      "label": "Hela (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "216a46d2-9143-591e-aa58-c95ad960bb4a",
+          "_name": "Laufey"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a8acb875-5a8b-560e-9bb8-5b34f93ce397",
+          "_name": "Frost Giant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "71283519-5467-588d-a99c-261e35b376a9",
+          "_name": "Frozen"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5e6c19a8-d11f-5bd8-a76b-0eac941f6720",
+          "_name": "Unnatural Storm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "452ddecd-5f59-5e08-8d25-22b70fac345c",
+          "_name": "Draugr"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "327e4ee3-2652-5ceb-99f8-85afb2f77dae",
+          "_name": "Fallen Warrior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fd15629d-e6a3-5282-bab7-ed4d11c11a8d",
+          "_name": "No Place for the Living"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8688abf2-2a15-5880-af03-d4d351b649e1",
+          "_name": "Legions of Hel"
+        }
+      ]
+    },
+    "Loki (recommends)": {
+      "label": "Loki (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7c3482be-5047-5094-b5ea-7d1c0a264bfe",
+          "_name": "Enchantress"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "88a5ff03-20c7-5200-b676-565b2d096b95",
+          "_name": "Beguiled"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c984f13b-4ef1-5426-a51e-bc92042e96e3",
+          "_name": "Seduced"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "216a46d2-9143-591e-aa58-c95ad960bb4a",
+          "_name": "Laufey"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a8acb875-5a8b-560e-9bb8-5b34f93ce397",
+          "_name": "Frost Giant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "71283519-5467-588d-a99c-261e35b376a9",
+          "_name": "Frozen"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5e6c19a8-d11f-5bd8-a76b-0eac941f6720",
+          "_name": "Unnatural Storm"
+        }
+      ]
+    },
+    "Risky Business (recommends)": {
+      "label": "Risky Business (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "91cf65ed-34da-5418-ba47-f634177ea631",
+          "_name": "Goblin Glider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2892c8a9-8c90-5ed5-bdb6-ef7a2300097e",
+          "_name": "Pumpkin Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d9c28195-36ae-58fc-929d-86d36e8dc038",
+          "_name": "Intimidation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "179fbff2-0685-5da4-a868-f1a2d17edf70",
+          "_name": "Regenerative Healing"
+        }
+      ]
+    },
+    "Mutagen Formula (recommends)": {
+      "label": "Mutagen Formula (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "91cf65ed-34da-5418-ba47-f634177ea631",
+          "_name": "Goblin Glider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "2892c8a9-8c90-5ed5-bdb6-ef7a2300097e",
+          "_name": "Pumpkin Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d9c28195-36ae-58fc-929d-86d36e8dc038",
+          "_name": "Intimidation"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "179fbff2-0685-5da4-a868-f1a2d17edf70",
+          "_name": "Regenerative Healing"
+        }
+      ]
+    },
+    "Nebula (recommends)": {
+      "label": "Nebula (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "823e143f-f7fc-5483-a90b-16d71f86819d",
+          "_name": "Pirate Commander"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "d3637349-a7ee-5352-b90b-8c68281be9b9",
+          "_name": "Pirate Lackey"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3fbe1bb9-e2c7-5577-9317-94c09285c805",
+          "_name": "Sound the Alarms"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "b259ede2-3035-50d0-a562-361306ee6f26",
+          "_name": "Honor Among Thieves"
+        }
+      ]
+    },
+    "Ronan the Accuser (recommends)": {
+      "label": "Ronan the Accuser (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "82c62c7c-0df9-51a6-8b23-c831cb1c84b1",
+          "_name": "Kree Combat Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "7adeb1b6-a442-55ca-b3c4-8ba67f983e26",
+          "_name": "Kree Commando"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "3750b2a1-c595-5d9c-8b06-8b28191d9932",
+          "_name": "Kree Lieutenant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "c0b2f9e7-d0cd-50e8-a91f-39351495fa04",
+          "_name": "Kree Private"
+        }
+      ]
+    },
+    "Taskmaster (recommends)": {
+      "label": "Taskmaster (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fecf8e5e-b9bf-571a-807d-5b02f7eca9cb",
+          "_name": "Combat Knife"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7c9e0604-3ca2-51cc-aa95-50cb84e90797",
+          "_name": "Hydra Sidearm"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "d94f00fc-03d9-536f-a2cf-c2e925b01228",
+          "_name": "Weapon Master"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "78391cb4-22b0-5c80-a7cc-6c135c2ba917",
+          "_name": "Concussion Grenade"
+        }
+      ]
+    },
+    "Thanos (recommends)": {
+      "label": "Thanos (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43fdc637-c3e3-59e9-a3c9-2569d79cfd73",
+          "_name": "Black Dwarf"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af63dfc3-2186-5422-bb33-c5bd4dea6715",
+          "_name": "Supergiant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "51e0cc3b-0983-5f49-955e-4a8cb28d8c68",
+          "_name": "The Black Order"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a0d2ac73-d416-55a6-b952-0c359714389b",
+          "_name": "Blood to Spare"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9b75ea59-41fc-5d35-b765-095d2c3f5ab0",
+          "_name": "Corvus Glaive"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6d81c708-24b6-5bec-8ae8-a98ddc0c5250",
+          "_name": "Proxima Midnight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "686e22c2-2399-54b9-8d1b-cc97315c04ca",
+          "_name": "Ebony Maw"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "9e150713-af28-5b7c-a45d-37c912e03ced",
+          "_name": "Tribute"
+        }
+      ]
+    },
+    "Tower Defense (recommends)": {
+      "label": "Tower Defense (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "a4dfc65c-0604-5033-9630-64d0d051f5f2",
+          "_name": "Black Order Infantry"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "def0b699-9b56-55f6-8943-b4800037b0ea",
+          "_name": "Outrider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f359f1ed-bbed-5ae4-845d-2074d5b86fe3",
+          "_name": "Landing Craft"
+        }
+      ]
+    },
+    "Zola (recommends)": {
+      "label": "Zola (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "53e4fdb4-6888-5351-b297-498285d36c3f",
+          "_name": "Under Attack"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "af2a0ce9-dc62-5e85-b02d-88eea7412c6e",
+          "_name": "Vibranium Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b6048f64-f3a1-5635-8c75-72fe67e4d6a7",
+          "_name": "Concussion Blasters"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "29661103-0fbc-55ba-929e-292d4a695e05",
+          "_name": "Concussive Blast"
+        }
+      ]
+    },
+    "Brotherhood of Badoon (recommends)": {
+      "label": "Brotherhood of Badoon (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "4e361b30-f822-56fd-9c36-e3ef83c5ecc3",
+          "_name": "Badoon Assassin"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "e18fd678-5f21-5737-b08e-8c6da2f0d780",
+          "_name": "Badoon Grunt"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "45f764b6-3df9-5e64-b781-c3960e53127c",
+          "_name": "Badoon Lieutenant"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "0339330e-bf11-534f-a73e-7b1e8a8a075a",
+          "_name": "Badoon Sentry"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "f0ed5670-d3c0-5cc3-baed-f5710afcb9a7",
+          "_name": "Badoon Warlord"
+        }
+      ]
+    },
+    "Sabretooth (recommends)": {
+      "label": "Sabretooth (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2e4d371f-121a-5026-a95f-d1cf018c9935",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "249f2dba-16bd-5926-b90d-713184a7231d",
+          "_name": "Blob"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "829f832a-4c4d-5ebe-8fd5-e733a7ee4cf8",
+          "_name": "Pyro"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adb49983-fa24-5a6f-b0e1-3c927a0a7f78",
+          "_name": "Toad"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c46d681c-43fa-58ed-88b9-d842c269dda7",
+          "_name": "Homo Superior"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "89c09d7f-e00d-5c5e-8572-2815c7a1d5db",
+          "_name": "Mutant Terrorists"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12741201-1920-59b0-b7a7-828565eee855",
+          "_name": "The Brotherhood"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "04c2cb0d-d2e1-50d0-8847-f59a98be90be",
+          "_name": "Mystique"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bd5618c0-3181-5439-9bb3-03d508a84fca",
+          "_name": "Metamorphic Mayhem"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8ba27fcf-288a-56f2-ac4a-a80cd554230d",
+          "_name": "Infiltration"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cbbdc5dd-bb0c-5916-a273-2cf387e1e060",
+          "_name": "Shapeshifter Surprise"
+        }
+      ]
+    },
+    "Project Wideawake (recommends)": {
+      "label": "Project Wideawake (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "6bff7ff9-7812-5307-a87c-fd87fe934051",
+          "_name": "Sentinel Mark V"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "ac2da7ef-a326-5519-96d4-b60bf66aa7bf",
+          "_name": "Sentinel Mark VI"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "5b8721de-ccf1-58e3-a659-da10eb85a9da",
+          "_name": "Targeted for Elimination"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "dee7b19d-f15a-57f3-aadb-c1e7b7788cbc",
+          "_name": "Relentless Robots"
+        }
+      ]
+    },
+    "Master Mold (recommends)": {
+      "label": "Master Mold (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "76a17f90-2129-5d2f-a92a-3b93fdc78bf9",
+          "_name": "Sentinel Mark II"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "39d48355-58a9-55cc-88f8-d2d9e8776a09",
+          "_name": "Sentinel Mark III"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "668e0cb6-0315-5e2a-85ab-a22f79e6e22e",
+          "_name": "Energy Barrier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c65aa8ac-ee8b-527c-8d66-ae62e5a9f77f",
+          "_name": "Operation Zero Tolerance"
+        }
+      ]
+    },
+    "Mansion Attack (recommends)": {
+      "label": "Mansion Attack (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "04c2cb0d-d2e1-50d0-8847-f59a98be90be",
+          "_name": "Mystique"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bd5618c0-3181-5439-9bb3-03d508a84fca",
+          "_name": "Metamorphic Mayhem"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "8ba27fcf-288a-56f2-ac4a-a80cd554230d",
+          "_name": "Infiltration"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cbbdc5dd-bb0c-5916-a273-2cf387e1e060",
+          "_name": "Shapeshifter Surprise"
+        }
+      ]
+    },
+    "Magneto (recommends)": {
+      "label": "Magneto (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f4f72a5f-bd65-52ea-ad82-cefb27ec0ef8",
+          "_name": "Fabian Cortez"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "138c924e-07c7-59bb-b2ce-baad73bb905f",
+          "_name": "Amelia Voght"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "26a02a40-f9b8-51ef-98d1-2adb47334bb8",
+          "_name": "Senyaka"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4cb80833-1f75-5496-9589-fbc4af4209b6",
+          "_name": "Delgado"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e04bdbbc-7ca6-54b3-96a8-5d3c1500e748",
+          "_name": "Unuscione"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "98c7bcfd-96b2-58e7-a797-1d4a9806671e",
+          "_name": "Zeal for the Cause"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "997b731f-eb27-51fa-b8d0-4daaed7e89e2",
+          "_name": "The Acolytes"
+        }
+      ]
+    },
+    "Sandman (recommends)": {
+      "label": "Sandman (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "828cf12e-1c0d-5852-a5f1-771b9abd54e1",
+          "_name": "Common Criminal"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ffe988b0-aa91-57f6-9df1-ae00b07a7711",
+          "_name": "Friends and Family"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6410f474-9ee6-50ea-a6ad-f90b62e3b8f0",
+          "_name": "Volunteer Work"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "735b0512-9087-51fd-9c36-3fe6ca1528dd",
+          "_name": "\"Threat or Menace?\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f1ac5331-3bf0-5530-81ec-c2a35d7ab93b",
+          "_name": "Loose Ends"
+        }
+      ]
+    },
+    "Mysterio (recommends)": {
+      "label": "Mysterio (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "10583ae5-966b-56ef-b63e-b38d08271ff2",
+          "_name": "Delusion of Collusion"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d1c4c962-8606-50d5-a7bf-c72b38f6d433",
+          "_name": "Manipulated Mind"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "eaa606f6-11e9-5570-9c9b-d49656b7d795",
+          "_name": "Old Grudge"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "382df7d8-b1c8-5884-9fc2-ceadb79a36cc",
+          "_name": "Analysis Paralysis"
+        }
+      ]
+    },
+    "Venom (recommends)": {
+      "label": "Venom (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "828cf12e-1c0d-5852-a5f1-771b9abd54e1",
+          "_name": "Common Criminal"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ffe988b0-aa91-57f6-9df1-ae00b07a7711",
+          "_name": "Friends and Family"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6410f474-9ee6-50ea-a6ad-f90b62e3b8f0",
+          "_name": "Volunteer Work"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "735b0512-9087-51fd-9c36-3fe6ca1528dd",
+          "_name": "\"Threat or Menace?\""
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f1ac5331-3bf0-5530-81ec-c2a35d7ab93b",
+          "_name": "Loose Ends"
+        }
+      ]
+    },
+    "Venom Goblin (recommends)": {
+      "label": "Venom Goblin (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c003ce1a-fac6-5b18-91f6-8a22470115f4",
+          "_name": "Advanced Glider"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f8e0ee0b-39a0-5f0b-987b-75e42e83ef48",
+          "_name": "Concussive Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "43c53db2-83bc-54a4-b22d-881e7a131647",
+          "_name": "Incendiary Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "78930bca-6d1d-5caf-adee-c22c276783ec",
+          "_name": "Smoke Bombs"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f7ce8a15-a768-5f19-980b-116f0554dcc6",
+          "_name": "Limitless Supply"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f6fd8aef-d5e9-5dff-93b8-5d454df55b8a",
+          "_name": "Remote Navigation"
+        }
+      ]
+    },
+    "Morlock Siege (recommends)": {
+      "label": "Morlock Siege (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "74e73f86-5ffd-5480-91fc-833f757d5a02",
+          "_name": "Heavy Armament"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fab801bd-2b0b-5970-8c34-c1da09fdfb57",
+          "_name": "Titanium Exoskeleton"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "01c50f0f-e616-568a-bb07-8db3dd5f280e",
+          "_name": "Inhibitor Collar"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "45491b68-5c19-572b-9155-680b0f0012d9",
+          "_name": "The Senator's Support"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2b5020bb-12ab-5428-bd78-1c609378e8ea",
+          "_name": "Vertigo"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "adc7631f-1955-51d7-bc87-85b811f97fe1",
+          "_name": "Mutant Slayers"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "48e4b9cb-c160-5fd6-925e-0b43ef5ae6b7",
+          "_name": "Bound by Business"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "d0b5ee34-867f-53fd-8905-5d00b6c331e7",
+          "_name": "Arclight"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "998f2ab6-0aca-5519-9fb6-5b0cc9427e4d",
+          "_name": "Blockbuster"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bde99f9e-1c71-5a7e-99ca-dbbfaa306063",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2a5b5c36-f6fd-5d06-9513-6e7fee1a3f89",
+          "_name": "Greycrow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5a0b2bf6-c83f-5d84-93a8-63157e7c9940",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "84f643ee-8378-53b5-9307-adcc0477510d",
+          "_name": "Riptide"
+        }
+      ]
+    },
+    "On the Run (recommends)": {
+      "label": "On the Run (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "74e73f86-5ffd-5480-91fc-833f757d5a02",
+          "_name": "Heavy Armament"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fab801bd-2b0b-5970-8c34-c1da09fdfb57",
+          "_name": "Titanium Exoskeleton"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "01c50f0f-e616-568a-bb07-8db3dd5f280e",
+          "_name": "Inhibitor Collar"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "45491b68-5c19-572b-9155-680b0f0012d9",
+          "_name": "The Senator's Support"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "179437f1-cad5-5f1b-99ad-839990360ad9",
+          "_name": "Gorgeous George"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "06e9e32e-05aa-54f8-a5a9-df905c45b84d",
+          "_name": "Hairbag"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b4d6664b-49b6-54f3-9861-e786a0a17b20",
+          "_name": "Ramrod"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bce1764b-24f4-592f-bcf5-df09b9fca8ec",
+          "_name": "Ruckus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b0363323-936a-53b5-8ea7-a8f91e28796e",
+          "_name": "Slab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db2acc5f-f8ac-5503-8005-862a1f0e5f3e",
+          "_name": "Get Nasty"
+        }
+      ]
+    },
+    "Juggernaut (recommends)": {
+      "label": "Juggernaut (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "f0c10124-b3c9-57ea-b224-563a5bbd834c",
+          "_name": "Black Tom Cassidy"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 4,
+          "databaseId": "413cf921-f4da-52ac-b193-dd369555a4a6",
+          "_name": "Creeping Willow"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "cb2becaf-6310-5e56-ade1-3e3f27a706d9",
+          "_name": "Making Green"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3dca8b6e-c5ad-511d-86e6-a33efa56ff31",
+          "_name": "A Sound Thrashing"
+        }
+      ]
+    },
+    "Mister Sinister (recommends)": {
+      "label": "Mister Sinister (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "179437f1-cad5-5f1b-99ad-839990360ad9",
+          "_name": "Gorgeous George"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "06e9e32e-05aa-54f8-a5a9-df905c45b84d",
+          "_name": "Hairbag"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b4d6664b-49b6-54f3-9861-e786a0a17b20",
+          "_name": "Ramrod"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bce1764b-24f4-592f-bcf5-df09b9fca8ec",
+          "_name": "Ruckus"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b0363323-936a-53b5-8ea7-a8f91e28796e",
+          "_name": "Slab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "db2acc5f-f8ac-5503-8005-862a1f0e5f3e",
+          "_name": "Get Nasty"
+        }
+      ]
+    },
+    "Unus (recommends)": {
+      "label": "Unus (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a74836c9-ef22-53b5-b9d3-85d7fe9d3042",
+          "_name": "Hunted"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fc418a6c-0b4d-5f12-a88e-959bccfc8fa7",
+          "_name": "War-Weary"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "94e0e1ce-8a9f-53d2-912c-8d3d8f454be4",
+          "_name": "Targeted for Extermination"
+        }
+      ]
+    },
+    "En Sabah Nur (recommends)": {
+      "label": "En Sabah Nur (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "37f6936b-d671-54d3-82fe-49b828f96ee3",
+          "_name": "Celestial Armor"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bc8191ba-94e8-596c-b797-4065b2edd63f",
+          "_name": "Celestial Weapon"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "c297ff6f-44f3-5393-a54e-b8050aa217b9",
+          "_name": "Celestial Tech"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3b524d41-26c0-535e-8a79-539d358a3480",
+          "_name": "Ozymandias"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8dc3e2e6-2392-5eb3-ab20-f24cba97a582",
+          "_name": "Scarab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 3,
+          "databaseId": "eedcbd12-1b47-5352-9d64-f05031b4a64a",
+          "_name": "Clan Akkaba Zealot"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9a6f845b-f075-535c-bf6e-c849b43500ad",
+          "_name": "Tyrant Worship"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ed8ba784-fccd-5b70-af65-3ec58f13ebd9",
+          "_name": "Ancient Ritual"
+        }
+      ]
+    },
+    "Dark Beast (recommends)": {
+      "label": "Dark Beast (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a74836c9-ef22-53b5-b9d3-85d7fe9d3042",
+          "_name": "Hunted"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fc418a6c-0b4d-5f12-a88e-959bccfc8fa7",
+          "_name": "War-Weary"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "94e0e1ce-8a9f-53d2-912c-8d3d8f454be4",
+          "_name": "Targeted for Extermination"
+        }
+      ]
+    },
+    "Apocalypse (recommends)": {
+      "label": "Apocalypse (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "286fcb20-2528-5209-bd27-0dfe93abd15b",
+          "_name": "Gauntlet"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "da4f8059-132b-575e-b1b4-59216802e473",
+          "_name": "Barrage"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8043247c-7755-5ade-b814-0bdfad5bd1ad",
+          "_name": "Hard-Drive"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "4a70b9f2-23d9-56bd-be3a-0f5f7f503470",
+          "_name": "Tusk"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "716167f8-e46d-55cb-ad8b-df4c6685fbe3",
+          "_name": "Psynapse"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "1e0dbecf-e054-5643-9485-05c53933b2e4",
+          "_name": "The Dark Riders"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9db49225-3bad-50dd-a8bc-ba23873a1b63",
+          "_name": "Infinite Soldier"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "aaf106a6-8751-55f0-916c-1ace93a1bb6c",
+          "_name": "Culling the Weak"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "01c842cb-66a5-55d0-bf3c-c0d7908fda97",
+          "_name": "Gene Pool"
+        }
+      ]
+    },
+    "Four Horsemen (recommends)": {
+      "label": "Four Horsemen (recommends)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a74836c9-ef22-53b5-b9d3-85d7fe9d3042",
+          "_name": "Hunted"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "fc418a6c-0b4d-5f12-a88e-959bccfc8fa7",
+          "_name": "War-Weary"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "94e0e1ce-8a9f-53d2-912c-8d3d8f454be4",
+          "_name": "Targeted for Extermination"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ecbcdcbb-1e7b-50b4-b920-5dc4f2ce0987",
+          "_name": "Release the Hounds"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "63a7cd11-9812-556c-8fe8-5f947778b5e1",
+          "_name": "Ahab"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "991e9a14-f053-56cf-9c24-ca3d56234c1b",
+          "_name": "Hound"
+        },
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7d6e9839-39d1-5439-9316-4647b4129589",
+          "_name": "Ahab's Energy Spear"
+        }
+      ]
+    },
+    "Hawkeye (marvelcdb bundle)": {
+      "label": "Hawkeye (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ceb9280c-e21f-52fb-8a0e-bdf377dcee42",
+          "_name": "Criminal Past"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7a03c821-53c2-5316-a47d-f7b1cd5044fe",
+          "_name": "Crossfire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9aeb2ff2-8647-50fc-97fe-f32995113113",
+          "_name": "Marked for Death"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d5137796-10b5-5795-9bfd-07000ae86d8b",
+          "_name": "Crossfire's Rifle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "76fcf525-83f8-57ed-b151-1bdb60f07b10",
+          "_name": "Sniper Shot"
+        }
+      ]
+    },
+    "Spider-Woman (marvelcdb bundle)": {
+      "label": "Spider-Woman (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "da567bf6-55c5-5630-962b-b5e33c8a0249",
+          "_name": "Uncertain Loyalties"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8cb8d93c-4abd-5ce8-b2f1-27bf7e66e834",
+          "_name": "The Viper"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "467ecf5e-aed1-520c-8bf6-66c5998d7b3f",
+          "_name": "The Viper's Ambition"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "1ce0fb5c-e959-5ce2-b94b-b058364ffbb0",
+          "_name": "Hydra Regular"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Groot (marvelcdb bundle)": {
+      "label": "Groot (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "47ea2afb-99e5-5e49-bea7-a10c67c77a5f",
+          "_name": "Wilt"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "724eabdc-4fba-57fe-b480-6b6c8564e445",
+          "_name": "Blazing Inferno"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13036687-3523-56f9-a505-3a1b1acb7031",
+          "_name": "Furnax"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "3eda870c-66c8-5ab5-b12a-0259678d9857",
+          "_name": "Fan the Flames"
+        }
+      ]
+    },
+    "Rocket Raccoon (marvelcdb bundle)": {
+      "label": "Rocket Raccoon (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b1027be1-0816-5c49-9253-d6a81546a72a",
+          "_name": "Crisis on Halfworld"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "55d3f010-0919-51f4-9f51-a60ad665b7e1",
+          "_name": "Vendetta"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "15394fd3-686d-54e0-b7a0-ce25fe119dea",
+          "_name": "Blackjack O'Hare"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0cbaccc6-628d-5563-ad90-76ffb2036be1",
+          "_name": "Blackjack's Bazooka"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "f064bccc-a091-5094-a720-84d780e6f5cb",
+          "_name": "Planetary Invasion"
+        }
+      ]
+    },
+    "Spectrum (marvelcdb bundle)": {
+      "label": "Spectrum (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "681e4fcc-07d7-5a8b-912d-6812ef7db0e0",
+          "_name": "Loss of Control"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8c2275d7-0ef8-5174-a2d4-cef01bd8a4ca",
+          "_name": "Radioactive Man"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "83c162e9-f6ca-5f98-9d9a-49c72c34c4b0",
+          "_name": "Reactor Meltdown"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "545442f3-338e-59af-87d9-9fdbf3394aa5",
+          "_name": "Sap Power"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d9d3007f-b938-5219-aa59-3bbd82f4a751",
+          "_name": "Radioactive Blast"
+        }
+      ]
+    },
+    "Adam Warlock (marvelcdb bundle)": {
+      "label": "Adam Warlock (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5682de05-eeea-5fba-aca9-1331d487d9f2",
+          "_name": "Regeneration Cycle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f2d47005-70ef-5492-99ff-c7a28334dc0f",
+          "_name": "The Magus"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b5d5552f-ead9-5052-b705-c3b301ebbf57",
+          "_name": "Universal Church of Truth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "5cd81d40-b9a0-561e-819a-3a3787cd35f0",
+          "_name": "Zealot of Truth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a9b28bc8-d0c0-50c4-b10a-da88032da97c",
+          "_name": "Cosmic Inquisition"
+        }
+      ]
+    },
+    "Ghost-Spider (marvelcdb bundle)": {
+      "label": "Ghost-Spider (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "470e2437-1f6d-5485-bdb2-4d20a947a3f7",
+          "_name": "Worried Father"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9017f11e-add0-5696-b210-cb536efcdf7b",
+          "_name": "Regenerative Research"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "922ea99b-fbec-504d-b2c9-19b2bb563188",
+          "_name": "The Lizard"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bc83222a-5ad9-5e91-a7cb-448a46f6b704",
+          "_name": "Experimental Injection"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ac52b622-4230-5536-ab64-43646850760c",
+          "_name": "In Cold Blood"
+        }
+      ]
+    },
+    "Spider-Man (Miles Morales) (marvelcdb bundle)": {
+      "label": "Spider-Man (Miles Morales) (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "03ae3c93-2b59-51b6-a866-70494e8d8c58",
+          "_name": "Keeping Secrets"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "19884b4d-93ea-562b-b795-2d3e1de29c04",
+          "_name": "Tracking Prey"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "025cc3d9-c45a-5f3e-b5a5-aaf8657c783a",
+          "_name": "Prowler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7d8ee4b2-4cef-5bd3-b0eb-2d6a15a3d5bd",
+          "_name": "Razor Claws"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "18b80aa8-78d6-5617-ae47-33d2bec4479b",
+          "_name": "Slice and Dice"
+        }
+      ]
+    },
+    "Colossus (marvelcdb bundle)": {
+      "label": "Colossus (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ef40dcd5-edd9-53ae-a594-e687150e7b7c",
+          "_name": "Homesick"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "203b16bf-638c-5638-9a04-e22b99f1cae4",
+          "_name": "Juggernaut"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c9e07021-7b3d-52b1-9d91-e5b5ef04558b",
+          "_name": "Rampaging Juggernaut"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "534d5409-2557-5289-ab0f-1f27d0fcc4ff",
+          "_name": "Unstoppable"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3902bc2c-d811-5fc5-9f27-d967664f1143",
+          "_name": "Slammed"
+        }
+      ]
+    },
+    "Shadowcat (marvelcdb bundle)": {
+      "label": "Shadowcat (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "8b596b6c-f0ed-5e9b-9c3c-a1629edd2f56",
+          "_name": "Permanently Phased"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ca74cb21-fd9e-556c-8ab9-4431782f44a5",
+          "_name": "White Queen"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2315085d-0f55-5f0c-8fc2-52b0867bc216",
+          "_name": "The Hellfire Club"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "7a02b51d-0608-5a57-baea-8b811364054a",
+          "_name": "Hellfire Pawn"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7b1a8f3a-8efa-52c7-bda3-fd91329fc943",
+          "_name": "Telepathic Restraint"
+        }
+      ]
+    },
+    "Cable (marvelcdb bundle)": {
+      "label": "Cable (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "8fff4cad-b621-5986-95cc-49c9ce8c9009",
+          "_name": "Technovirus Resurgence"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "90fad8cf-092e-557d-974c-6e4e55b64cd5",
+          "_name": "Stryfe"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8f9e0e0b-4b1c-51f2-ba4e-63f22224001f",
+          "_name": "Back to the Future"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f0393598-514a-57ef-80c9-a1e4417adb56",
+          "_name": "Telekinetic Force Field"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9177ed8a-f99f-57f0-b6a5-3cdc4fd6e6e8",
+          "_name": "Mind Scan"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "33059b17-96a0-5fd8-a618-421d53d0fed3",
+          "_name": "Telekinetic Blast"
+        }
+      ]
+    },
+    "Domino (marvelcdb bundle)": {
+      "label": "Domino (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0db2034d-fccb-5cc2-8758-94fcb6044e44",
+          "_name": "Memories of Armageddon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "465d6036-80fb-5c2d-84d2-621baec1356a",
+          "_name": "Topaz"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8f5cfc57-1c19-5415-98f5-65cd7c16786f",
+          "_name": "Not My Lucky Day"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1d26179a-b37e-5248-b586-0a4e553a548a",
+          "_name": "Prototype"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "19eb5273-4d1d-58b6-bab1-6553a8ada5e7",
+          "_name": "Superpower Feedback"
+        }
+      ]
+    },
+    "Bishop (marvelcdb bundle)": {
+      "label": "Bishop (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "3e261fbf-455c-57d8-98be-c665ff1691bf",
+          "_name": "Fear the Future"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2f7c82b3-437b-566c-96e4-fcadb7b587d6",
+          "_name": "Trevor Fitzroy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dd337ce4-c136-5e08-bd2f-55d4f35f4d70",
+          "_name": "Portal Through Time"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2bda35f9-bb46-5dca-9b3c-7432a6443cd3",
+          "_name": "Bantam"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "5f47fdc1-033a-50ca-b002-4dab223dc9ba",
+          "_name": "Temporal Trickery"
+        }
+      ]
+    },
+    "Magik (marvelcdb bundle)": {
+      "label": "Magik (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "fcd7e1b7-abc1-5a9b-b71b-1b30d0b76525",
+          "_name": "Darkchilde"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b39a7ed4-4520-596a-911c-1e584d85ca8b",
+          "_name": "Belasco"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0f51675-84b1-57d8-bd18-d5b1ea14a0c1",
+          "_name": "Ruler of Limbo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cef26124-5a22-5c2c-a0a3-c2bcc416a4e9",
+          "_name": "S'ym"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4480f6ee-d377-5df7-b528-6ff6b0e9af3e",
+          "_name": "Witchfire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3cca9390-d213-5c09-8366-ccb60621b4b7",
+          "_name": "Battle for Limbo"
+        }
+      ]
+    },
+    "Captain America (marvelcdb bundle)": {
+      "label": "Captain America (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "64a104f3-9bef-5186-a600-c3b7ca98937c",
+          "_name": "Man Out of Time"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "e72a7871-8f2b-5624-97a7-940d1f57a705",
+          "_name": "Hit Squad"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f6658570-036f-5d10-a68a-dd79d30bd972",
+          "_name": "Baron Zemo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "07ae991d-6ae9-5f7f-9846-210d76bcc820",
+          "_name": "Hydra Soldier"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d0eb5526-30f8-5d5f-b5ab-7a0bccab150c",
+          "_name": "Hail Hydra!"
+        }
+      ]
+    },
+    "Ms. Marvel (marvelcdb bundle)": {
+      "label": "Ms. Marvel (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "b2ad396f-8b81-5cba-a034-d71be9924e21",
+          "_name": "Home by Dawn"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "16f3ed1b-8509-52b3-a0d8-50e55a59c5fd",
+          "_name": "Generation Why?"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2018c44d-9dc9-532d-8295-e9ddb4946ce1",
+          "_name": "Thomas Edison"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2294b2e6-27cc-5611-9f96-ee1df53aaf00",
+          "_name": "Edison's Giant Robot"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "53fe1558-ab2e-5fae-9179-f98ac59963d6",
+          "_name": "Harvest"
+        }
+      ]
+    },
+    "Thor (marvelcdb bundle)": {
+      "label": "Thor (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "05fc5d0d-4b79-5d29-9d58-0a47e5ecb563",
+          "_name": "Odin's Anger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4a5a56c4-1b0a-5c38-a49d-8219935d9194",
+          "_name": "Family Feud"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "fd9cf4b5-6421-5640-8da5-83bda653fdc7",
+          "_name": "Loki"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "a8acb875-5a8b-560e-9bb8-5b34f93ce397",
+          "_name": "Frost Giant"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13a27c61-46ae-53cc-8a96-fe8a1f6af294",
+          "_name": "Trickster"
+        }
+      ]
+    },
+    "Black Widow (marvelcdb bundle)": {
+      "label": "Black Widow (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "037bee61-72e2-560b-9407-ecac9b499202",
+          "_name": "Burn Notice"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1cb1c397-6151-5831-a2c3-de834a035edb",
+          "_name": "Taskmaster"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c64b2b72-b430-5ef0-8233-3313570a5c01",
+          "_name": "Killer for Hire"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ad69696c-7e2e-5c2d-a9bf-30d5eb4cf293",
+          "_name": "Hydra Mercenary"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "99282c78-c6a1-521f-9c28-c5dcd36ca5fb",
+          "_name": "Deadly Shot"
+        }
+      ]
+    },
+    "Doctor Strange (marvelcdb bundle)": {
+      "label": "Doctor Strange (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9d10b930-4c96-5371-94fa-0869fd9f8530",
+          "_name": "Physical Toll"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f48e490c-f9c8-5302-aa46-e3cab3c93521",
+          "_name": "Baron Mordo"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2082491b-0a7d-5db2-9779-6f60204541ba",
+          "_name": "Open the Dark Dimension"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "99d3688d-4bab-562e-a254-32bd08c8c1a8",
+          "_name": "Counterspell"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7ca114b6-5b59-56ed-8ba5-438cd3b03527",
+          "_name": "Thoughtcasting"
+        }
+      ]
+    },
+    "Hulk (marvelcdb bundle)": {
+      "label": "Hulk (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "2b7a5899-9fc2-5dad-a37e-242b6d2ef1a5",
+          "_name": "Inner Demons"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ae31d512-9c24-5afc-9bb8-f13da4740f68",
+          "_name": "Abomination"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "40d4e6e4-5ecc-5e42-8bf1-10691e43e580",
+          "_name": "Total Destruction"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "e296822a-afc0-58e1-b69b-1a5843d12300",
+          "_name": "Clash of the Titans"
+        }
+      ]
+    },
+    "Ant-Man (marvelcdb bundle)": {
+      "label": "Ant-Man (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "61dae78b-4aa9-57c8-b89c-4250872b7dbb",
+          "_name": "Care for Cassie"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7776c68c-eead-59c0-8d46-864230de9333",
+          "_name": "Tech Theft"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "29f392ce-7c37-533f-a9c4-7ed22cda3744",
+          "_name": "Yellowjacket"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "6721a8d8-998c-5ce8-8a92-3ecabd0f51af",
+          "_name": "Size Increase"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "fbbb2299-ec8a-523a-aedb-962f3ef9da4b",
+          "_name": "Yellowjacket's Plan"
+        }
+      ]
+    },
+    "Wasp (marvelcdb bundle)": {
+      "label": "Wasp (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c828c026-01a5-5d73-9ab7-63037cb9db83",
+          "_name": "Red Dreams"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "934da0e3-db0c-5eea-ba53-4d3f475fc6b6",
+          "_name": "Mother's Orders"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "68fa97f7-420a-59bd-97a4-2a57d55d3d4c",
+          "_name": "Beetle"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ea039f4b-9308-5dd5-875c-fbcdb4521745",
+          "_name": "Beetle Armor MK IV"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "836f1abe-3d2b-5d9d-a195-88ea219f3624",
+          "_name": "Beetle Mania"
+        }
+      ]
+    },
+    "Quicksilver (marvelcdb bundle)": {
+      "label": "Quicksilver (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "123dea31-26d6-58fa-8ec4-64feee842cd5",
+          "_name": "Need for Speed"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5fb7d482-37ce-57c1-80ec-c23ca80d167c",
+          "_name": "Extortion of Seismic Proportion"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b0b51e3a-4c78-5d8d-b53d-79415c6c5c2c",
+          "_name": "Avalanche"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "36427cb3-ed51-5d71-acdd-d860a40fcd83",
+          "_name": "Vibration Resistance"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "bb593e7c-8724-5a75-9384-6872f3dcfced",
+          "_name": "Earthquake"
+        }
+      ]
+    },
+    "Scarlet Witch (marvelcdb bundle)": {
+      "label": "Scarlet Witch (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 2,
+          "databaseId": "10ce750e-7581-515a-a02b-6375b3ca1d47",
+          "_name": "Slipping Sanity"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0cc0edc8-35eb-53b9-bb20-40d30366f20d",
+          "_name": "The Next Evolution"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c3950111-c45b-58da-a552-8b7220004550",
+          "_name": "Luminous"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a9620606-7e6b-5eb6-8034-297a612d2c0a",
+          "_name": "Magical Suspension"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "656abd7c-fde7-5c1e-95cf-54df63f251a6",
+          "_name": "Chaos Manipulation"
+        }
+      ]
+    },
+    "Star-Lord (marvelcdb bundle)": {
+      "label": "Star-Lord (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9244f1fa-5e7c-59f4-95ef-fe976348c975",
+          "_name": "Banishment"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dfa846f0-12f1-5238-b0d0-c87012e47907",
+          "_name": "Budding Crime Syndicate"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3d49a40f-2e39-5af1-9e18-c008923407dd",
+          "_name": "Mister Knife"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "0c7a07de-ed17-5d46-a3d4-5bf602dedfbc",
+          "_name": "Spartoi Cunning"
+        }
+      ]
+    },
+    "Gamora (marvelcdb bundle)": {
+      "label": "Gamora (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "ef19ca05-f38f-5a6c-8ecf-8f1c2326d1bc",
+          "_name": "Unfulfilled Destiny"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "0191e363-3fbf-5647-96c1-ee7fd78f9932",
+          "_name": "Sibling Rivalry"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2ca9ae57-070d-51b7-8377-978ca0d78dd1",
+          "_name": "Nebula"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4226b99c-4c08-5d6e-9d08-78218c64d085",
+          "_name": "In a Bind"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0d815c4a-0684-5894-a78c-400d3b6d3df8",
+          "_name": "Waylay"
+        }
+      ]
+    },
+    "Drax (marvelcdb bundle)": {
+      "label": "Drax (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "625ce78a-1caa-512b-929f-b40150803ead",
+          "_name": "Memories of Another Life"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "eae5c7a6-09e5-5ad9-9272-801b29c4218c",
+          "_name": "Cull the Weak"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c3959350-7aec-5020-be66-6ffc6201a859",
+          "_name": "Yotat the Destroyer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "da980a1a-4e73-58ef-9dda-551c0e96a097",
+          "_name": "Challenge Accepted"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "e175c2e3-37ed-5776-aa99-fa8d78d3b49f",
+          "_name": "\"I Will Destroy You!\""
+        }
+      ]
+    },
+    "Venom (marvelcdb bundle)": {
+      "label": "Venom (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "5f7a3411-238d-5314-b45a-82c7ba6fe679",
+          "_name": "Struggle for Control"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b4179629-ae89-583e-a26e-fcd1f152e3da",
+          "_name": "Klyntar Frenzy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 4,
+          "databaseId": "7f2c2deb-dbac-595f-baff-5974ec577055",
+          "_name": "Enraged Symbiote"
+        }
+      ]
+    },
+    "Nebula (marvelcdb bundle)": {
+      "label": "Nebula (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e5439a28-188b-58ac-823a-d7186b14351b",
+          "_name": "Inferiority Complex"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5e644c46-fb25-53cb-afbf-6539e2da5406",
+          "_name": "Gamora"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f1070231-5489-52cf-9784-8c517838ea49",
+          "_name": "Self-Preservation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "605c704e-d1ce-55f9-8c84-f601c11fe6b7",
+          "_name": "Lethal Weapon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "2554e7c3-7788-5cad-b540-484da132765c",
+          "_name": "Old Rivals"
+        }
+      ]
+    },
+    "War Machine (marvelcdb bundle)": {
+      "label": "War Machine (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c14c4381-7412-589e-b384-b1679cf00ca6",
+          "_name": "Equipment Malfunction"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "e6897454-1b25-5665-93bd-cd07a0faede7",
+          "_name": "Living Laser"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "874bcf7c-a027-593c-b25f-77c5aad2b640",
+          "_name": "Deadly Light Show"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "557c125e-3d38-5c9c-930f-e03daa7b0385",
+          "_name": "Laser Strike"
+        }
+      ]
+    },
+    "Valkyrie (marvelcdb bundle)": {
+      "label": "Valkyrie (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a95e8710-d931-568e-83f1-73a4a80a71e5",
+          "_name": "Trouble in Otherworld"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7c3482be-5047-5094-b5ea-7d1c0a264bfe",
+          "_name": "Enchantress"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b07258cf-1715-5479-937f-2ab61b5f8afb",
+          "_name": "Powerful Enchantments"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "88a5ff03-20c7-5200-b676-565b2d096b95",
+          "_name": "Beguiled"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "c984f13b-4ef1-5426-a51e-bc92042e96e3",
+          "_name": "Seduced"
+        }
+      ]
+    },
+    "Vision (marvelcdb bundle)": {
+      "label": "Vision (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "46cdfa8e-2b80-5a49-b1fe-3b1a806e49ff",
+          "_name": "Corrupted Programming"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7f4341cd-5fc3-555c-8a94-e3a7304d195a",
+          "_name": "Ultron"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "13331cd6-ecd4-5d6a-bfe3-00f156d6d871",
+          "_name": "Ultron Unleashed"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8dc89688-080f-55ec-a557-c469bc9b4705",
+          "_name": "Ultron Drones"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "cccd4ecb-70e2-5629-8f4f-87ec8c42340f",
+          "_name": "Relentless Android"
+        }
+      ]
+    },
+    "Nova (marvelcdb bundle)": {
+      "label": "Nova (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "7ea95a07-96bb-504a-8438-5c5b69467003",
+          "_name": "Weight of the World"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ffdf414b-4c29-5bcc-b159-d25513884637",
+          "_name": "\"Bring the War!\""
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d2d20a3a-ee49-56de-a10c-4892bcbadd9f",
+          "_name": "Warbringer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "06e31034-789a-536f-ae99-a0d8e172cc79",
+          "_name": "War Delivery"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b0619561-7b86-59db-9fc5-89f0e428aaf7",
+          "_name": "\"The War's Been Brought\""
+        }
+      ]
+    },
+    "Ironheart (marvelcdb bundle)": {
+      "label": "Ironheart (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "37882d1b-5f85-5f87-8a26-1f8c72681030",
+          "_name": "A Minor Setback"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6656ec87-7505-5be7-90e0-b06aa5a9bb20",
+          "_name": "Rule by Force"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8a627fe6-38a6-5d19-bb99-f7e97e5903dd",
+          "_name": "Lucia von Bardas"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f6fd3422-28bd-57a5-b0dd-c501f7a19b48",
+          "_name": "Cyborg Tech"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "7d81af68-3b3a-5716-b795-347853eab319",
+          "_name": "Political Retribution"
+        }
+      ]
+    },
+    "Ironheart (Version Upgrades)": {
+      "label": "Ironheart (Version Upgrades)",
+      "cards": [
+        {
+          "loadGroupId": "playerNOutOfPlay",
+          "quantity": 1,
+          "databaseId": "0006bfd8-06a5-5928-8d17-1b4971407dbc",
+          "_name": "Ironheart"
+        },
+        {
+          "loadGroupId": "playerNOutOfPlay",
+          "quantity": 1,
+          "databaseId": "23858611-0f2c-5e28-8aae-cc9258600557",
+          "_name": "Ironheart"
+        }
+      ]
+    },
+    "Spider-Ham (marvelcdb bundle)": {
+      "label": "Spider-Ham (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6cf69f7a-ac07-5920-8656-72597be47093",
+          "_name": "\"I Really Want a Hot Dog!\""
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b04bf7b8-b4fe-5fad-a023-d1ef1123c083",
+          "_name": "Nefarious Trap"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7cae1c5f-d081-58b3-abd8-0bf859a013d9",
+          "_name": "The Green Gobbler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "399db354-07cc-5183-9c86-ed2a3d101efb",
+          "_name": "Gobbler Glider"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "b5c44837-aff4-5b73-837c-a60f4f9f4992",
+          "_name": "\"Feast on This!\""
+        }
+      ]
+    },
+    "SP\/\/dr (marvelcdb bundle)": {
+      "label": "SP\/\/dr (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "a7442ad5-0454-5757-8982-7283f688be07",
+          "_name": "Inherited Burden"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "dc3b9db3-b828-5d70-9a3d-481d0a4e11dc",
+          "_name": "Giant Monster Attack"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e2a0786-ec19-5212-b20d-9746c856377f",
+          "_name": "M.O.R.B.I.U.S."
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "50052124-b233-54d4-8691-ccb66fc8ae01",
+          "_name": "Energy Drain"
+        }
+      ]
+    },
+    "SP\/\/dr (Peni Parker)": {
+      "label": "SP\/\/dr (Peni Parker)",
+      "cards": [
+        {
+          "loadGroupId": "playerNPlay1",
+          "quantity": 1,
+          "databaseId": "36943f94-3731-5bed-9b56-59fbdd69f968",
+          "_name": "Peni Parker"
+        }
+      ]
+    },
+    "Cyclops (marvelcdb bundle)": {
+      "label": "Cyclops (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "9a1d1fe3-441e-585c-b3fa-4223e2cf9388",
+          "_name": "Lost Visor"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "693134be-fe55-5474-b040-79b0e723fd83",
+          "_name": "Mister Sinister"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "df1fc64d-49f4-5c95-8766-4ead875cc68e",
+          "_name": "Genetic Manipulation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "b3da2fcf-54ec-5f94-9403-2e5a14a253a3",
+          "_name": "Gene Therapy"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "346efd23-9edf-56e2-90e9-28c7fc91a66e",
+          "_name": "Concussive Force"
+        }
+      ]
+    },
+    "Phoenix (marvelcdb bundle)": {
+      "label": "Phoenix (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "13213966-29c7-578e-9f93-0196cc33ada1",
+          "_name": "Burning Hunger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4ddb5a14-d451-5461-bd5f-0b06a9149ff7",
+          "_name": "Dark Phoenix"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7b5bf070-c823-5529-9d83-bb8536702dd3",
+          "_name": "Consume the World"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "f1701c79-ffe4-5acb-a6ab-9de7f8d85067",
+          "_name": "Fiery Rage"
+        }
+      ]
+    },
+    "Wolverine (marvelcdb bundle)": {
+      "label": "Wolverine (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "bc87c9b4-a796-5b66-858b-58652dd898f5",
+          "_name": "Past Demons"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "70d3dc78-c085-53be-a62c-9c924ad5379b",
+          "_name": "Omega Red"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4766ef75-9673-5ecf-a018-75c2fdcb878d",
+          "_name": "The Carbonadium Synthesizer"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "e2dff0f1-9464-5936-ae7a-d736a6c1cb33",
+          "_name": "Death Factor"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cd4f7476-0040-5d74-bc01-cd477e6c8319",
+          "_name": "Tentacle Strike"
+        }
+      ]
+    },
+    "Storm (marvelcdb bundle)": {
+      "label": "Storm (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "812fd07a-67d2-5a41-bc20-5cd10ea8714c",
+          "_name": "Claustrophobia"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "aa650bb8-1a52-54c7-960f-4935da33fd92",
+          "_name": "Callisto"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "1228f8c0-c3b5-5457-95ad-7652f2a8f45b",
+          "_name": "Leader of the Morlocks"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bfa5d40b-40ca-5448-94bf-3d0cf13ae5f0",
+          "_name": "Switchblade"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "69115abc-91e8-5852-8469-23ff7cffe356",
+          "_name": "Knife Fight"
+        }
+      ]
+    },
+    "Gambit (marvelcdb bundle)": {
+      "label": "Gambit (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "82553ca6-1e12-5e65-8fd4-0aab4ddc174a",
+          "_name": "Guild Business"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8396636d-b794-5d09-8e88-9c298f6917d7",
+          "_name": "Belladonna"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ed06e4bd-7f06-573e-b7c8-5dd7fbc54ab5",
+          "_name": "The Assassins Guild"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "ab888ed8-d1c9-5676-a272-26116fc89f15",
+          "_name": "Guild Assassin"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "5526c793-d0a4-505a-bae5-a0e6f2a23988",
+          "_name": "Assassination Attempt"
+        }
+      ]
+    },
+    "Rogue (marvelcdb bundle)": {
+      "label": "Rogue (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "33913ba8-022b-59ef-9c2f-fb43dbbdcb6e",
+          "_name": "Deadly Touch"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "147bc502-92fc-5a36-9720-b1aad5f6ed5e",
+          "_name": "Mystique"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "654de6d8-a651-5d81-8a03-a13584a0285e",
+          "_name": "Mystique's Manipulations"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 3,
+          "databaseId": "b5d22aa7-42b1-567a-8364-65bce1c1b6f9",
+          "_name": "Misled"
+        }
+      ]
+    },
+    "Psylocke (marvelcdb bundle)": {
+      "label": "Psylocke (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "12504bf5-96bc-58c8-b35e-ec45704fe9a1",
+          "_name": "Body Swapped"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "04e36b35-eea5-576d-aa95-3a4806f072ec",
+          "_name": "Chimera"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "49772c93-55a3-5285-b5a2-6b25b69610cd",
+          "_name": "Interdimensional Plunder"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "02413aa1-9fde-5a00-b773-ed4e74a9e695",
+          "_name": "Psionic Illusion"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "38901ca1-98c4-5879-b6d4-d2c7d32d170a",
+          "_name": "Telekinetic Dragon"
+        }
+      ]
+    },
+    "Angel (marvelcdb bundle)": {
+      "label": "Angel (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "e5ce8ddc-f51d-579c-aa70-1d202859ad27",
+          "_name": "Apocalyptic Influence"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e8b827d-9c4c-58e6-bbfe-7653ebb50d48",
+          "_name": "Harpoon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "546e2387-ac0a-5bdd-a1fc-e34a36016c9b",
+          "_name": "Hook, Line, and Sinker"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "2533c75a-3e8f-58c0-8690-c5df47d1c68a",
+          "_name": "Harpoon's Harpoon"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0c787957-e8c6-55da-a410-82ba0cf9a003",
+          "_name": "Spear Shot"
+        }
+      ]
+    },
+    "X-23 (marvelcdb bundle)": {
+      "label": "X-23 (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "c1e80964-526f-5515-8a6e-30c0cfef5953",
+          "_name": "Self-Isolation"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "4d19da80-db22-52e0-9241-abb18f3590f1",
+          "_name": "Lady Deathstrike"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "7bf1f7ec-2c6b-5eec-882a-843b2b8cc044",
+          "_name": "In the Name of Vengeance"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "c4bc6d31-2009-579b-9cca-cb90b34d5e1a",
+          "_name": "Cybermods"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "de21d2db-a5f8-5338-83ba-c8ed22c8178b",
+          "_name": "Critical Wound"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3176a069-83ed-530e-8dc7-d04bf846b8e2",
+          "_name": "Hack 'n' Slash"
+        }
+      ]
+    },
+    "Deadpool (marvelcdb bundle)": {
+      "label": "Deadpool (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6092c310-46fb-5e7d-b6b6-166ffbd18f10",
+          "_name": "The Merc with the Mouth"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6b51f1af-8313-5de4-aa4c-7f5541e85ad2",
+          "_name": "Butler"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "8ac08952-c2a2-5e95-9978-b02a475d3e25",
+          "_name": "Involuntary Procedures"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "bb08f813-9731-5744-94de-34037fbc74d6",
+          "_name": "Tabula Rasa 16"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "4e3644eb-e202-5357-96be-6f1bb1fc933f",
+          "_name": "Mutated Soldier"
+        }
+      ]
+    },
+    "She-Hulk (marvelcdb bundle)": {
+      "label": "She-Hulk (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "0b283953-807a-5dee-bc9d-04d95bf89fd3",
+          "_name": "Legal Work"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "41e2ac26-891a-57d1-a459-3f735a6c76cd",
+          "_name": "Personal Challenge"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "ef79cb43-c539-56be-8dcc-7049461e7509",
+          "_name": "Titania"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "6d0678c5-e0c4-5d34-8cd6-3c3e481f6d2a",
+          "_name": "Genetically Enhanced"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "03d696bb-d3ac-592d-9600-a19b7f8be060",
+          "_name": "Titania's Fury"
+        }
+      ]
+    },
+    "Spider-Man (marvelcdb bundle)": {
+      "label": "Spider-Man (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "76fc3fac-9453-599b-83f3-2ee7bdba01c0",
+          "_name": "Eviction Notice"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "a44fff25-a7bf-5c09-a4cd-056efe983e37",
+          "_name": "Highway Robbery"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "40288e53-42ee-556c-952a-9b38a8124379",
+          "_name": "Vulture"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "0c745dcf-71ba-5321-b883-4f3fd62b10d2",
+          "_name": "Sweeping Swoop"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "d9a2dba5-2f0b-5062-99d5-6101a409ed39",
+          "_name": "The Vulture's Plans"
+        }
+      ]
+    },
+    "Black Panther (marvelcdb bundle)": {
+      "label": "Black Panther (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "6f4fc111-1227-5b50-afd7-d34bbece6c4e",
+          "_name": "Affairs of State"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "f2da76be-01fc-5e4b-9f83-0f65a4ae23f1",
+          "_name": "Usurp the Throne"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b7f17901-4c4d-598e-b244-c8f04bab4b7d",
+          "_name": "Killmonger"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "baa3f8c1-cd1d-5ad9-9fb7-49d3f4db8a0c",
+          "_name": "Heart-Shaped Herb"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "a809331b-5b5c-5d14-8a03-522f4b5de635",
+          "_name": "Ritual Combat"
+        }
+      ]
+    },
+    "Iron Man (marvelcdb bundle)": {
+      "label": "Iron Man (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "99f7c301-230d-502c-b70f-a3f5639e0fc3",
+          "_name": "Business Problems"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "3759d8cb-8447-50ed-95ff-076afde556fb",
+          "_name": "Imminent Overload"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "b56e5bea-6732-5290-9233-a7b12ebc0de6",
+          "_name": "Whiplash"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "49e6e3a7-12ad-52ad-82b8-a906e06cbe1c",
+          "_name": "Electric Whip Attack"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "9e095eab-f3d6-5148-957f-331531eb572f",
+          "_name": "Electromagnetic Backlash"
+        }
+      ]
+    },
+    "Captain Marvel (marvelcdb bundle)": {
+      "label": "Captain Marvel (marvelcdb bundle)",
+      "cards": [
+        {
+          "loadGroupId": "sharedEncounterDeck",
+          "quantity": 1,
+          "databaseId": "038d9eb4-dcaf-59ad-98d5-2b56dd54909f",
+          "_name": "Family Emergency"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "196a9d70-ff93-5d7e-8b65-a3c3a027846a",
+          "_name": "The Psyche-Magnitron"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "20498295-0c47-59ae-8e15-987247906d7b",
+          "_name": "Yon-Rogg"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 2,
+          "databaseId": "87bec687-5f1c-5082-99e8-11fa81996b4a",
+          "_name": "Kree Manipulator"
+        },
+        {
+          "loadGroupId": "playerNNemesisSet",
+          "quantity": 1,
+          "databaseId": "cd6328e7-2acc-5d3e-86f8-c41c189bdc26",
+          "_name": "Yon-Rogg's Treason"
+        }
+      ]
+    }
+  }
+}

--- a/json/prompts.json
+++ b/json/prompts.json
@@ -1,0 +1,22 @@
+{
+  "prompts": {
+    "importMc4dbDeck": {
+      "args": [],
+      "message": "Paste an mc4db deck URL (e.g., https://mc4db.merlindumesnil.net/decklist/view/61)",
+      "input": {
+        "type": "text"
+      },
+      "options": [
+        {
+          "label": "Import Deck",
+          "hotkey": "Enter",
+          "code": ["ACTION_LIST", "importMc4dbDeck"]
+        },
+        {
+          "label": "Cancel",
+          "hotkey": "Escape"
+        }
+      ]
+    }
+  }
+}

--- a/json/prompts.json
+++ b/json/prompts.json
@@ -2,7 +2,7 @@
   "prompts": {
     "importMc4dbDeck": {
       "args": [],
-      "message": "Paste an mc4db deck URL (e.g., https://mc4db.merlindumesnil.net/decklist/view/61)",
+      "message": "Paste an mc4db deck URL (e.g., https://mc4db.merlindumesnil.net/decklist/view/1)",
       "input": {
         "type": "text"
       },


### PR DESCRIPTION
- Adds Ctrl+K hotkey to import a deck by pasting an mc4db URL (e.g. \`https://mc4db.merlindumesnil.net/decklist/view/61\` or \`/deck/view/N\`)
- Fetches hero + slot card JSON via DragnLang REQUEST_JSON; builds inline cardDetails without needing cards in the local DB
- Hero loaded two-sided (Hero/Alter-Ego) into play area; deck cards loaded with player card back
- handSize, hitPoints, and loadedDeck set by normal automation post-load

## Bug fixes
- **postLoadActionList**: guards the marvelcdb bundle LOAD_CARDS with a \$GAME_DEF.preBuiltDecks check so custom-imported cards don't crash
- **SP//dr escaping**: fixed SP//dr being treated as a JS comment by the game def merger, corrupting those JSON files"