### PR TITLE
Fix Red Skull expert campaign obligation card backs

### DIFF
--- a/src/dragncards/database.rs
+++ b/src/dragncards/database.rs
@@ -14,6 +14,7 @@ const ANDROID_EFFICIENCY_ID_BASE: &'static str = "01144";
 const FIRECRACKER_ID_BASE: &'static str = "47007";
 const FLASH_OF_LIGHT_ID_BASE: &'static str = "47008";
 const PLASMOID_ENERGY_ID_BASE: &'static str = "47010";
+const REDSKULL_EXPERT_CAMPAIGN_OBLIGATION_IDS: &[&str] = &["04163", "04164", "04165", "04166"];
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -227,6 +228,10 @@ fn image_url(card: &CerebroCard, printing: &Printing) -> String {
 }
 
 fn card_back(card: &CerebroCard) -> CardBack {
+    if REDSKULL_EXPERT_CAMPAIGN_OBLIGATION_IDS.contains(&card.id.as_str()) {
+        return CardBack::Player;
+    }
+
     // Wakanda Forever uses A/B/C/D in id, but are not multi-sided cards
     if !card.id.contains(WAKANDA_FOREVER_ID_BASE)
         && !card.id.contains(ANDROID_EFFICIENCY_ID_BASE)


### PR DESCRIPTION
This is a simple fix aiming to correct the card backs for the Red Skull expert campaign. According to the rules, these are supposed to have player backs (blue) instead of encounter ones (orange).

<img width="670" height="390" alt="image" src="https://github.com/user-attachments/assets/6ba41181-7efd-4810-b75b-67dc2ec6aceb" />


## Result

<img width="790" height="262" alt="Screenshot 2026-06-09 at 09 23 01" src="https://github.com/user-attachments/assets/bdb665bb-b9dd-4f1a-9a5a-7fdc6bf7d310" />
