### PR TITLE
Fix: So far in the games that I played (escape the museum, Nebula, Ronan) the

### DIFF
--- a/json/defaultActions.json
+++ b/json/defaultActions.json
@@ -13,13 +13,19 @@
         {
           "actionList": "flipCard",
           "label": "id:flipButton",
-          "condition": ["EQUAL", "$ACTIVE_CARD.currentSide", "B"],
+          "condition": ["AND", ["EQUAL", "$ACTIVE_CARD.currentSide", "B"], ["NOT", ["EQUAL", "$ACTIVE_FACE.type", "Main Scheme"]]],
           "position": "bottom"
         },
         {
           "actionList": "flipCard",
           "label": "id:flipButton",
           "condition": ["EQUAL", "$ACTIVE_FACE.type", "Hero"],
+          "position": "bottom"
+        },
+        {
+          "actionList": "flipCard",
+          "label": "id:flipButton",
+          "condition": ["AND", ["EQUAL", "$ACTIVE_FACE.type", "Main Scheme"], ["EQUAL", "$ACTIVE_CARD.currentSide", "A"]],
           "position": "bottom"
         },
         {


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413108723396618/1531044096632815636

**Description:**
> So far in the games that I played (escape the museum, Nebula, Ronan) the default actions on the main schemes are backwards. The A sides of the schemes (that have the setup stuff) have the thwart and discard action when you click on the card, and the B side (that is up during play) has the click to flip action on it.
