### PR TITLE
Fix: facedown cards still show 'exhaust' — NOT is unsupported in default-action conditions

### DIFF
--- a/json/defaultActions.json
+++ b/json/defaultActions.json
@@ -13,7 +13,7 @@
         {
           "actionList": "flipCard",
           "label": "id:flipButton",
-          "condition": ["AND", ["EQUAL", "$ACTIVE_CARD.currentSide", "B"], ["NOT", ["EQUAL", "$ACTIVE_CARD.sides.A.type", "Main Scheme"]]],
+          "condition": ["AND", ["EQUAL", "$ACTIVE_CARD.currentSide", "B"], ["NOT_EQUAL", "$ACTIVE_CARD.sides.A.type", "Main Scheme"]],
           "position": "bottom"
         },
         {


### PR DESCRIPTION
Follow-up to #79, which merged before this fix landed. `main` is still affected.

## Problem

#79 guarded the generic "flip if facedown" rule in `json/defaultActions.json` with `["NOT", ["EQUAL", ...]]`. Default-action conditions are evaluated by `frontend/src/features/engine/hooks/evaluate.js`, a much smaller evaluator than the one used for action lists. Its entire opcode set is:

`LIST, AND, OR, EQUAL, LESS_THAN, GREATER_THAN, LESS_EQUAL, GREATER_EQUAL, NOT_EQUAL, IN_STRING, OBJ_GET_BY_PATH`

`NOT` is not among them, so the clause falls off the end of the `switch`, returns `undefined`, and drags the whole `AND` to false. The flip rule never matches, and every facedown card falls through to the final rule — `toggleExhaust`. That is the original reported bug, unchanged.

Verified against the deployed bundle as well: `frontend/build/static/js/main.41d77bf5.js` contains `case"NOT_EQUAL"` but no `case"NOT"`, so this is not a stale-source artifact.

`NOT` *is* valid in `automation.json` and `functions.json`, which run through the fuller evaluator — likely how it got used here.

## Fix

Swap in the supported `NOT_EQUAL`. It coerces an undefined operand via `|| 0`, so a card with no `sides.A.type` compares unequal to `"Main Scheme"` and stays flippable, which is the wanted behavior.

The Main Scheme rule added in #79 uses only `AND` and `EQUAL` and was never affected; it is unchanged here.

## Testing

Diff is one line and the JSON parses. Not exercised in a running game — worth a click on a facedown encounter card before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)