### PR TITLE
Fix: save game touch bar action referenced a nonexistent engine action

### DIFF
--- a/json/touchBar.json
+++ b/json/touchBar.json
@@ -179,10 +179,10 @@
               "actionList": "undo"
             },
             {
-              "id": "save",
+              "id": "saveGame",
               "label": "Save",
               "actionType": "engine",
-              "actionList": "save"
+              "actionList": "saveGame"
             }
         ]
     ]


### PR DESCRIPTION
The Save button in the touch bar pointed at an engine action named `save`, which does not exist. The engine's dispatcher handles `saveGame` (`frontend/src/features/engine/hooks/useDragnHotkeys.js:150`); there is no `save` case, so the button did nothing.

Renames both the button `id` and its `actionList` to `saveGame`.

## Testing

Two-line change and the JSON parses. Not exercised in a running game — worth a click on the touch bar Save button before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)